### PR TITLE
Add mandatory patch version verification as Step 0

### DIFF
--- a/rails-upgrade/CHANGELOG.md
+++ b/rails-upgrade/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## v3.1 — March 2026
+- Added mandatory Step 0: Verify Latest Patch Version — ensures app is on latest patch of current series before any minor/major hop
+- Added latest patch versions reference table in `reference/multi-hop-strategy.md`
+- Updated workflow from 4-step to 5-step process
+- All request patterns now include Step 0 patch verification
+- Updated Key Principles and Success Criteria to include patch verification
+
+## v3.0
+- **MAJOR:** Removed script generation - Claude now runs detection directly using tools
+- Detection uses Grep, Glob, and Read tools instead of generating bash scripts
+- Eliminated user round-trip (no more "run this script and share results")
+- Streamlined detection from 5-step to 4-step process
+- New workflow file: `workflows/direct-detection-workflow.md`
+- Removed: `workflows/detection-script-workflow.md`, `examples/detection-script-only.md`
+
+## v2.2
+- Added mandatory `load_defaults` verification as Step 2 of all upgrade workflows
+- If `load_defaults` is behind current Rails version, skill now:
+  - Informs user of the mismatch
+  - Recommends updating `load_defaults` to match current Rails BEFORE upgrading to next version
+  - Asks user for confirmation before proceeding
+- ~~New workflow file: `workflows/load-defaults-verification-workflow.md`~~ (removed in v3.0 — replaced by external `rails-load-defaults` skill dependency)
+
+## v2.1
+- Added mandatory test suite verification as Step 1 of all upgrade workflows
+- Upgrade process now BLOCKS if any tests fail
+- New workflow file: `workflows/test-suite-verification-workflow.md`

--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -59,7 +59,9 @@ When proposing code fixes that must work with both the current and target Rails 
 ### Step 0: Verify Latest Patch Version (MANDATORY PRE-STEP)
 - **CRITICAL:** Before any upgrade work begins, verify the app is on the latest patch release of its current Rails series
 - Read `Gemfile.lock` to find the exact current Rails version (e.g., `3.2.19`)
-- Compare against the latest patch for that series (see `reference/multi-hop-strategy.md` for the reference table)
+- Compare against the latest patch for that series:
+  - **EOL series (≤ 6.1):** Use the static table in `reference/multi-hop-strategy.md`
+  - **Active series (≥ 7.0):** Query the RubyGems API at runtime (see `reference/multi-hop-strategy.md` for commands)
 - If the app is NOT on the latest patch:
   - Inform user: "Your app is on Rails X.Y.Z but the latest patch is X.Y.W — you should upgrade to the latest patch first"
   - Guide user through updating the Gemfile and running `bundle update rails`
@@ -235,8 +237,9 @@ When user requests an upgrade, follow this workflow:
 ⚠️  THIS STEP IS REQUIRED BEFORE ANY OTHER WORK
 
 1. Read Gemfile.lock to find exact current Rails version (e.g., 3.2.19)
-2. Compare against latest patch for that series
-   (see reference/multi-hop-strategy.md — "Latest Patch Versions Reference" table)
+2. Compare against latest patch for that series:
+   - EOL series (≤ 6.1): use static table in reference/multi-hop-strategy.md
+   - Active series (≥ 7.0): query RubyGems API (see reference/multi-hop-strategy.md for commands)
 3. If current version < latest patch:
    - INFORM user: "Your app is on Rails X.Y.Z but the latest patch is X.Y.W"
    - Guide through Gemfile update and bundle update rails

--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -3,11 +3,11 @@ name: rails-upgrade
 description: Analyzes Rails applications and generates comprehensive upgrade reports with breaking changes, deprecations, and step-by-step migration guides for Rails 2.3 through 8.1. Use when upgrading Rails applications, planning multi-hop upgrades, or querying version-specific changes. Based on FastRuby.io methodology and "The Complete Guide to Upgrade Rails" ebook.
 ---
 
-# Rails Upgrade Assistant Skill v2.0
+# Rails Upgrade Assistant Skill v3.1
 
 ## Skill Identity
 - **Name:** Rails Upgrade Assistant
-- **Version:** 3.0
+- **Version:** 3.1
 - **Purpose:** Intelligent Rails application upgrades from 2.3 through 8.1
 - **Based on:** Official Rails CHANGELOGs, FastRuby.io methodology, and the FastRuby.io ebook
 - **Upgrade Strategy:** Sequential only (no version skipping)
@@ -54,7 +54,19 @@ When proposing code fixes that must work with both the current and target Rails 
 
 ---
 
-## Core Workflow (4-Step Process)
+## Core Workflow (5-Step Process)
+
+### Step 0: Verify Latest Patch Version (MANDATORY PRE-STEP)
+- **CRITICAL:** Before any upgrade work begins, verify the app is on the latest patch release of its current Rails series
+- Read `Gemfile.lock` to find the exact current Rails version (e.g., `3.2.19`)
+- Compare against the latest patch for that series (see `reference/multi-hop-strategy.md` for the reference table)
+- If the app is NOT on the latest patch:
+  - Inform user: "Your app is on Rails X.Y.Z but the latest patch is X.Y.W — you should upgrade to the latest patch first"
+  - Guide user through updating the Gemfile and running `bundle update rails`
+  - Run test suite after patch upgrade to verify nothing broke
+  - Deploy patch upgrade before proceeding with the minor/major version hop
+- If the app IS on the latest patch → Proceed to Step 1
+- **Why:** Patch releases contain security fixes, bug fixes, and additional deprecation warnings that make the next version hop safer and easier to debug
 
 ### Step 1: Run Test Suite (MANDATORY FIRST STEP)
 - **CRITICAL:** Before any upgrade work begins, run the existing test suite
@@ -218,6 +230,23 @@ If user requests a multi-hop upgrade (e.g., 5.2 → 8.1):
 
 When user requests an upgrade, follow this workflow:
 
+### Step 0: Verify Latest Patch Version (MANDATORY PRE-STEP)
+```
+⚠️  THIS STEP IS REQUIRED BEFORE ANY OTHER WORK
+
+1. Read Gemfile.lock to find exact current Rails version (e.g., 3.2.19)
+2. Compare against latest patch for that series
+   (see reference/multi-hop-strategy.md — "Latest Patch Versions Reference" table)
+3. If current version < latest patch:
+   - INFORM user: "Your app is on Rails X.Y.Z but the latest patch is X.Y.W"
+   - Guide through Gemfile update and bundle update rails
+   - Run test suite after patch upgrade
+   - Deploy patch upgrade before proceeding
+   - Do NOT proceed to next minor/major until on latest patch
+4. If current version == latest patch:
+   - Proceed to Step 1
+```
+
 ### Step 1: Run Test Suite (MANDATORY FIRST STEP)
 ```
 ⚠️  THIS STEP IS REQUIRED BEFORE ANY OTHER WORK
@@ -347,6 +376,12 @@ Before starting ANY upgrade:
 ### Pattern 1: Full Upgrade Request
 **User says:** "Upgrade my Rails app to 8.1"
 
+**Action - Step 0 (MANDATORY: Verify Latest Patch):**
+1. Read `Gemfile.lock` for exact Rails version
+2. Compare against latest patch for that series (see `reference/multi-hop-strategy.md`)
+3. If not on latest patch → Guide user through patch upgrade first
+4. If on latest patch → Proceed to Step 1
+
 **Action - Step 1 (MANDATORY: Verify Tests Pass):**
 1. Load: `workflows/test-suite-verification-workflow.md`
 2. Detect test framework (RSpec or Minitest)
@@ -381,6 +416,11 @@ Before starting ANY upgrade:
 ### Pattern 2: Multi-Hop Request
 **User says:** "Help me upgrade from Rails 5.2 to 8.1"
 
+**Action - Step 0 (MANDATORY: Verify Latest Patch):**
+1. Check exact current version from `Gemfile.lock`
+2. If not on latest patch of current series → Upgrade to latest patch first
+3. For multi-hop: This check applies at the START and again after each hop
+
 **Action - Step 1 (MANDATORY: Verify Tests Pass):**
 1. Run test suite BEFORE planning any upgrade work
 2. If tests fail → STOP and fix first
@@ -401,6 +441,9 @@ Before starting ANY upgrade:
 
 ### Pattern 3: Breaking Changes Analysis Only
 **User says:** "What breaking changes affect my app for Rails 8.0?"
+
+**Action - Step 0 (MANDATORY: Verify Latest Patch):**
+1. Check if on latest patch — warn if not, recommend patching first
 
 **Action - Step 1 (MANDATORY: Verify Tests Pass):**
 1. Run test suite first
@@ -447,19 +490,20 @@ Before delivering, verify:
 
 ## Key Principles
 
-1. **ALWAYS Run Test Suite First** (MANDATORY - no exceptions, no upgrade work until tests pass)
-2. **Block on Failing Tests** (if tests fail, STOP and help fix them before any upgrade work)
-3. **ALWAYS Verify load_defaults** (MANDATORY - check if load_defaults matches current Rails version)
-4. **Recommend Updating load_defaults First** (if behind current Rails, update load_defaults BEFORE upgrading to next version)
-5. **Run Detection Directly** (use Grep/Glob/Read tools - no script generation needed)
-6. **Always Use Actual Findings** (no generic examples in reports)
-7. **Always Flag Custom Code** (with ⚠️ warnings based on detected issues)
-8. **Always Use Templates** (for consistency)
-9. **Always Check Quality** (before delivery)
-10. **Load Workflows as Needed** (don't hold everything in memory)
-11. **Sequential Process is Critical** (tests → load_defaults check → detection → reports)
-12. **Follow FastRuby.io Methodology** (incremental upgrades, assessment first)
-13. **Always Use `NextRails.next?` for Dual-Boot Code** (NEVER use `respond_to?` for version branching. DELEGATE to the `dual-boot` skill for patterns and setup.)
+1. **ALWAYS Verify Latest Patch First** (MANDATORY - ensure app is on latest patch of current series before any version hop)
+2. **ALWAYS Run Test Suite** (MANDATORY - no exceptions, no upgrade work until tests pass)
+3. **Block on Failing Tests** (if tests fail, STOP and help fix them before any upgrade work)
+4. **ALWAYS Verify load_defaults** (MANDATORY - check if load_defaults matches current Rails version)
+5. **Recommend Updating load_defaults First** (if behind current Rails, update load_defaults BEFORE upgrading to next version)
+6. **Run Detection Directly** (use Grep/Glob/Read tools - no script generation needed)
+7. **Always Use Actual Findings** (no generic examples in reports)
+8. **Always Flag Custom Code** (with ⚠️ warnings based on detected issues)
+9. **Always Use Templates** (for consistency)
+10. **Always Check Quality** (before delivery)
+11. **Load Workflows as Needed** (don't hold everything in memory)
+12. **Sequential Process is Critical** (patch check → tests → load_defaults check → detection → reports)
+13. **Follow FastRuby.io Methodology** (incremental upgrades, assessment first)
+14. **Always Use `NextRails.next?` for Dual-Boot Code** (NEVER use `respond_to?` for version branching. DELEGATE to the `dual-boot` skill for patterns and setup.)
 
 ---
 
@@ -467,7 +511,9 @@ Before delivering, verify:
 
 A successful upgrade assistance session:
 
-✅ **Ran test suite FIRST** (Step 1 - MANDATORY)
+✅ **Verified latest patch version** (Step 0 - MANDATORY)
+✅ **Upgraded to latest patch if needed** (before any minor/major hop)
+✅ **Ran test suite** (Step 1 - MANDATORY)
 ✅ **Verified all tests pass** (blocked if tests failed)
 ✅ **Recorded baseline metrics** (test count, coverage)
 ✅ **Checked load_defaults alignment** (Step 2 - MANDATORY)
@@ -483,17 +529,24 @@ A successful upgrade assistance session:
 
 ---
 
-**Version:** 3.0
-**Last Updated:** January 2025
+**Version:** 3.1
+**Last Updated:** March 2026
 **Skill Type:** Modular with external workflows and examples
 **Methodology:** Based on FastRuby.io upgrade best practices and "The Complete Guide to Upgrade Rails" ebook
 **Attribution:** Content based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)
+
+**v3.1 Changes:**
+- Added mandatory Step 0: Verify Latest Patch Version — ensures app is on latest patch of current series before any minor/major hop
+- Added latest patch versions reference table in `reference/multi-hop-strategy.md`
+- Updated workflow from 4-step to 5-step process
+- All request patterns now include Step 0 patch verification
+- Updated Key Principles and Success Criteria to include patch verification
 
 **v3.0 Changes:**
 - **MAJOR:** Removed script generation - Claude now runs detection directly using tools
 - Detection uses Grep, Glob, and Read tools instead of generating bash scripts
 - Eliminated user round-trip (no more "run this script and share results")
-- Streamlined from 5-step to 4-step process
+- Streamlined detection from 5-step to 4-step process
 - New workflow file: `workflows/direct-detection-workflow.md`
 - Removed: `workflows/detection-script-workflow.md`, `examples/detection-script-only.md`
 

--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -3,14 +3,15 @@ name: rails-upgrade
 description: Analyzes Rails applications and generates comprehensive upgrade reports with breaking changes, deprecations, and step-by-step migration guides for Rails 2.3 through 8.1. Use when upgrading Rails applications, planning multi-hop upgrades, or querying version-specific changes. Based on FastRuby.io methodology and "The Complete Guide to Upgrade Rails" ebook.
 ---
 
-# Rails Upgrade Assistant Skill v3.1
+# Rails Upgrade Assistant Skill
 
 ## Skill Identity
 - **Name:** Rails Upgrade Assistant
-- **Version:** 3.1
 - **Purpose:** Intelligent Rails application upgrades from 2.3 through 8.1
-- **Based on:** Official Rails CHANGELOGs, FastRuby.io methodology, and the FastRuby.io ebook
+- **Skill Type:** Modular with external workflows and examples
 - **Upgrade Strategy:** Sequential only (no version skipping)
+- **Methodology:** Based on FastRuby.io upgrade best practices and "The Complete Guide to Upgrade Rails" ebook
+- **Attribution:** Content based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)
 
 ---
 
@@ -532,36 +533,4 @@ A successful upgrade assistance session:
 
 ---
 
-**Version:** 3.1
-**Last Updated:** March 2026
-**Skill Type:** Modular with external workflows and examples
-**Methodology:** Based on FastRuby.io upgrade best practices and "The Complete Guide to Upgrade Rails" ebook
-**Attribution:** Content based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)
-
-**v3.1 Changes:**
-- Added mandatory Step 0: Verify Latest Patch Version — ensures app is on latest patch of current series before any minor/major hop
-- Added latest patch versions reference table in `reference/multi-hop-strategy.md`
-- Updated workflow from 4-step to 5-step process
-- All request patterns now include Step 0 patch verification
-- Updated Key Principles and Success Criteria to include patch verification
-
-**v3.0 Changes:**
-- **MAJOR:** Removed script generation - Claude now runs detection directly using tools
-- Detection uses Grep, Glob, and Read tools instead of generating bash scripts
-- Eliminated user round-trip (no more "run this script and share results")
-- Streamlined detection from 5-step to 4-step process
-- New workflow file: `workflows/direct-detection-workflow.md`
-- Removed: `workflows/detection-script-workflow.md`, `examples/detection-script-only.md`
-
-**v2.2 Changes:**
-- Added mandatory `load_defaults` verification as Step 2 of all upgrade workflows
-- If `load_defaults` is behind current Rails version, skill now:
-  - Informs user of the mismatch
-  - Recommends updating `load_defaults` to match current Rails BEFORE upgrading to next version
-  - Asks user for confirmation before proceeding
-- ~~New workflow file: `workflows/load-defaults-verification-workflow.md`~~ (removed in v3.0 — replaced by external `rails-load-defaults` skill dependency)
-
-**v2.1 Changes:**
-- Added mandatory test suite verification as Step 1 of all upgrade workflows
-- Upgrade process now BLOCKS if any tests fail
-- New workflow file: `workflows/test-suite-verification-workflow.md`
+See [CHANGELOG.md](CHANGELOG.md) for version history and current version.

--- a/rails-upgrade/reference/multi-hop-strategy.md
+++ b/rails-upgrade/reference/multi-hop-strategy.md
@@ -30,26 +30,53 @@ Before beginning any minor or major version hop, ensure you are on the **latest 
 
 ### Latest Patch Versions Reference
 
-| Series | Latest Patch | Notes |
-|--------|-------------|-------|
-| 2.3.x | 2.3.18 | End of life |
-| 3.0.x | 3.0.20 | End of life |
-| 3.1.x | 3.1.12 | End of life |
-| 3.2.x | 3.2.22.5 | End of life |
-| 4.0.x | 4.0.13 | End of life |
-| 4.1.x | 4.1.16 | End of life |
-| 4.2.x | 4.2.11.3 | End of life |
-| 5.0.x | 5.0.7.2 | End of life |
-| 5.1.x | 5.1.7 | End of life |
-| 5.2.x | 5.2.8.1 | End of life |
-| 6.0.x | 6.0.6.1 | End of life |
-| 6.1.x | 6.1.7.10 | End of life |
-| 7.0.x | 7.0.8.7 | Security only |
-| 7.1.x | 7.1.5.1 | Security only |
-| 7.2.x | 7.2.2.1 | Maintained |
-| 8.0.x | 8.0.2 | Maintained |
+#### End-of-Life Series (static — these versions are frozen)
 
-> **Note:** This table may become outdated. Always verify against [rubygems.org](https://rubygems.org/gems/rails/versions) before starting an upgrade.
+| Series | Latest Patch |
+|--------|-------------|
+| 2.3.x | 2.3.18 |
+| 3.0.x | 3.0.20 |
+| 3.1.x | 3.1.12 |
+| 3.2.x | 3.2.22.5 |
+| 4.0.x | 4.0.13 |
+| 4.1.x | 4.1.16 |
+| 4.2.x | 4.2.11.3 |
+| 5.0.x | 5.0.7.2 |
+| 5.1.x | 5.1.7 |
+| 5.2.x | 5.2.8.1 |
+| 6.0.x | 6.0.6.1 |
+| 6.1.x | 6.1.7.10 |
+
+#### Active Series (look up dynamically — these receive new patches)
+
+For series that are still maintained or receiving security updates, **always resolve the latest patch at runtime** using one of these methods:
+
+**Option A — RubyGems API (preferred, structured JSON):**
+```bash
+curl -s https://rubygems.org/api/v1/versions/rails.json | \
+  ruby -rjson -e '
+    series = ARGV[0]
+    versions = JSON.parse(STDIN.read)
+      .map { |v| v["number"] }
+      .select { |v| v.start_with?(series) }
+      .sort_by { |v| Gem::Version.new(v) }
+    puts versions.last
+  ' "7.1."
+```
+Replace `"7.1."` with the target series prefix (e.g., `"7.0."`, `"7.2."`, `"8.0."`).
+
+**Option B — gem search (works offline if gem sources are cached):**
+```bash
+gem search '^rails$' --versions | grep "^rails " | \
+  ruby -e '
+    series = ARGV[0]
+    versions = STDIN.read.scan(/[\d.]+/).select { |v| v.start_with?(series) }
+      .sort_by { |v| Gem::Version.new(v) }
+    puts versions.last
+  ' "7.1."
+```
+
+> **Why dynamic?** Active series receive new patch releases for security and bug fixes. A hard-coded table goes stale; querying RubyGems ensures the skill always targets the correct version.
 
 ### Process
 

--- a/rails-upgrade/reference/multi-hop-strategy.md
+++ b/rails-upgrade/reference/multi-hop-strategy.md
@@ -4,9 +4,67 @@
 
 ---
 
-## Core Principle
+## Core Principles
 
-**Never skip Rails versions.** Upgrade sequentially, one minor/major version at a time.
+1. **Never skip Rails versions.** Upgrade sequentially, one minor/major version at a time.
+2. **Always start from the latest patch of your current version.** Before hopping to the next minor/major, upgrade to the latest patch release of your current series first.
+
+---
+
+## Step 0: Upgrade to Latest Patch Release
+
+Before beginning any minor or major version hop, ensure you are on the **latest patch release** of your current Rails series. For example, if you are on Rails 3.2.19, upgrade to 3.2.22.5 first.
+
+### Why This Matters
+
+- **Security fixes** — Patch releases contain critical security patches that may also exist in the next minor version. Starting from the latest patch ensures you're not carrying known vulnerabilities.
+- **Bug fixes** — Later patches fix bugs that could cause confusing failures during an upgrade, making it harder to distinguish pre-existing issues from upgrade-related ones.
+- **Deprecation warnings** — Later patch releases may include additional deprecation warnings that prepare you for the next version.
+- **Smaller delta** — The jump to the next minor/major is smaller and better tested from the latest patch than from an arbitrary earlier patch.
+
+### How to Find the Latest Patch
+
+1. Check [rubygems.org/gems/rails/versions](https://rubygems.org/gems/rails/versions) for all releases in your series
+2. Or run: `gem search rails --versions | grep "^rails "` to see available versions
+3. The latest patch for each series is the target before hopping
+
+### Latest Patch Versions Reference
+
+| Series | Latest Patch | Notes |
+|--------|-------------|-------|
+| 2.3.x | 2.3.18 | End of life |
+| 3.0.x | 3.0.20 | End of life |
+| 3.1.x | 3.1.12 | End of life |
+| 3.2.x | 3.2.22.5 | End of life |
+| 4.0.x | 4.0.13 | End of life |
+| 4.1.x | 4.1.16 | End of life |
+| 4.2.x | 4.2.11.3 | End of life |
+| 5.0.x | 5.0.7.2 | End of life |
+| 5.1.x | 5.1.7 | End of life |
+| 5.2.x | 5.2.8.1 | End of life |
+| 6.0.x | 6.0.6.1 | End of life |
+| 6.1.x | 6.1.7.10 | End of life |
+| 7.0.x | 7.0.8.7 | Security only |
+| 7.1.x | 7.1.5.1 | Security only |
+| 7.2.x | 7.2.2.1 | Maintained |
+| 8.0.x | 8.0.2 | Maintained |
+
+> **Note:** This table may become outdated. Always verify against [rubygems.org](https://rubygems.org/gems/rails/versions) before starting an upgrade.
+
+### Process
+
+```
+1. Read Gemfile.lock to find exact current Rails version (e.g., 3.2.19)
+2. Look up latest patch for that series (e.g., 3.2.22.5)
+3. If current version < latest patch:
+   a. Update Gemfile: gem 'rails', '3.2.22.5'
+   b. Run: bundle update rails
+   c. Run test suite — all tests must pass
+   d. Review CHANGELOG for security fixes and behavioral changes
+   e. Deploy patch upgrade to production
+   f. Monitor for issues
+4. Once on latest patch, proceed to Step 1 (Map Your Path)
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a mandatory **Step 0: Verify Latest Patch Version** to the upgrade workflow
- Before hopping to the next minor/major Rails version, the skill now checks that the app is on the latest patch release of its current series (e.g., 3.2.19 → 3.2.22.5 before jumping to 4.0.x)
- Splits patch version lookup into **static table for EOL series** (≤ 6.1) and **dynamic RubyGems API lookups for active series** (≥ 7.0)
- Extracts version history into a standalone **CHANGELOG.md** and consolidates skill metadata into the Skill Identity section

## Why

The official Rails upgrade guide and community best practices (FastRuby.io, Shopify, GitHub) all recommend upgrading to the latest patch of the current series before attempting a minor/major version hop. Reasons:

- **Security fixes** in later patches that you'd carry as vulnerabilities otherwise
- **Bug fixes** that could cause confusing failures during upgrade, making it hard to distinguish pre-existing issues from upgrade-related ones
- **Additional deprecation warnings** in later patches that prepare for the next version
- **Smaller delta** — the jump to the next minor/major is better tested from the latest patch

The static/dynamic split prevents the patch versions table from going stale — EOL series are frozen forever, while active series are resolved at runtime via the RubyGems JSON API or `gem search`.

## Changes

- `SKILL.md`: Added Step 0 to core workflow, all request patterns, Key Principles, and Success Criteria. Consolidated metadata into Skill Identity section. Removed inline changelog.
- `reference/multi-hop-strategy.md`: Added "Step 0: Upgrade to Latest Patch Release" section with static EOL table and dynamic lookup commands for active series.
- `CHANGELOG.md`: New file — single source of truth for version history.

## Test plan

- [ ] Verify skill triggers Step 0 when app is not on latest patch
- [ ] Verify skill skips Step 0 when app is already on latest patch
- [ ] Verify EOL table values against rubygems.org
- [ ] Verify dynamic RubyGems API lookup returns correct latest patch for active series
