### PR TITLE
Package as Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,8 @@
 {
-  "name": "ombulabs-rails-upgrade",
+  "name": "fastruby-upgrade-rails",
+  "metadata": {
+    "description": "Claude Code plugins for Rails upgrades by OmbuLabs.ai, based on FastRuby.io methodology."
+  },
   "owner": {
     "name": "OmbuLabs.ai",
     "url": "https://www.ombulabs.ai"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "ombulabs-rails-upgrade",
+  "owner": {
+    "name": "OmbuLabs.ai",
+    "url": "https://www.ombulabs.ai"
+  },
+  "plugins": [
+    {
+      "name": "rails-upgrade",
+      "source": "./",
+      "description": "Analyzes Rails applications and generates comprehensive upgrade reports with breaking changes, deprecations, and step-by-step migration guides for Rails 2.3 through 8.1. Based on FastRuby.io methodology.",
+      "version": "3.1.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
   },
   "repository": "https://github.com/ombulabs/claude-code_rails-upgrade-skill",
   "homepage": "https://www.ombulabs.ai",
-  "skills": "./rails-upgrade",
+  "skills": "./",
   "keywords": [
     "ruby",
     "rails",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,8 +4,12 @@
   "version": "3.1.0",
   "author": {
     "name": "OmbuLabs.ai",
-    "url": "https://www.ombulabs.ai"
+    "url": "https://www.ombulabs.ai",
+    "email": "hello@ombulabs.com"
   },
+  "repository": "https://github.com/ombulabs/claude-code_rails-upgrade-skill",
+  "homepage": "https://www.ombulabs.ai",
+  "skills": "rails-upgrade",
   "keywords": [
     "ruby",
     "rails",
@@ -13,6 +17,9 @@
     "migration",
     "fastruby",
     "breaking-changes",
-    "deprecations"
+    "tech-debt",
+    "deprecations",
+    "legacy-code",
+    "ruby-on-rails"
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rails-upgrade",
   "description": "Analyzes Rails applications and generates comprehensive upgrade reports with breaking changes, deprecations, and step-by-step migration guides for Rails 2.3 through 8.1. Based on FastRuby.io methodology.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "OmbuLabs.ai",
     "url": "https://www.ombulabs.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "rails-upgrade",
+  "description": "Analyzes Rails applications and generates comprehensive upgrade reports with breaking changes, deprecations, and step-by-step migration guides for Rails 2.3 through 8.1. Based on FastRuby.io methodology.",
+  "version": "3.0.0",
+  "author": {
+    "name": "OmbuLabs.ai",
+    "url": "https://www.ombulabs.ai"
+  },
+  "keywords": [
+    "ruby",
+    "rails",
+    "upgrade",
+    "migration",
+    "fastruby",
+    "breaking-changes",
+    "deprecations"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
   },
   "repository": "https://github.com/ombulabs/claude-code_rails-upgrade-skill",
   "homepage": "https://www.ombulabs.ai",
-  "skills": "rails-upgrade",
+  "skills": "./rails-upgrade",
   "keywords": [
     "ruby",
     "rails",

--- a/README.md
+++ b/README.md
@@ -43,9 +43,17 @@ git clone https://github.com/ombulabs/claude-code_dual-boot-skill.git
 cp -r claude-code_dual-boot-skill/dual-boot ~/.claude/skills/dual-boot
 ```
 
-### Installation
+### Installation (Plugin)
 
-Add this skill to your Claude Code configuration:
+Install as a Claude Code plugin for automatic setup:
+
+```bash
+claude plugin add --from https://github.com/ombulabs/claude-code_rails-upgrade-skill
+```
+
+### Installation (Manual)
+
+Alternatively, add this skill manually to your Claude Code configuration:
 
 ```bash
 # Clone the repository

--- a/README.md
+++ b/README.md
@@ -45,13 +45,24 @@ cp -r claude-code_dual-boot-skill/dual-boot ~/.claude/skills/dual-boot
 
 ### Installation (Plugin)
 
-Install as a Claude Code plugin with a single command:
+Add the marketplace and install the plugin:
 
 ```bash
-claude plugin install rails-upgrade@ombulabs/claude-code_rails-upgrade-skill
+# Add the marketplace (one-time setup)
+claude plugin marketplace add ombulabs/claude-code_rails-upgrade-skill
+
+# Install the plugin
+claude plugin install rails-upgrade@ombulabs-rails-upgrade
 ```
 
-Or for local testing from a cloned repo:
+Or from within Claude Code:
+
+```
+/plugin marketplace add ombulabs/claude-code_rails-upgrade-skill
+/plugin install rails-upgrade@ombulabs-rails-upgrade
+```
+
+For local testing from a cloned repo:
 
 ```bash
 claude --plugin-dir ./claude-code_rails-upgrade-skill

--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ cp -r claude-code_dual-boot-skill/dual-boot ~/.claude/skills/dual-boot
 
 ### Installation (Plugin)
 
-Install as a Claude Code plugin for automatic setup:
+Install as a Claude Code plugin with a single command:
 
 ```bash
-claude plugin add --from https://github.com/ombulabs/claude-code_rails-upgrade-skill
+claude plugin install rails-upgrade@ombulabs/claude-code_rails-upgrade-skill
+```
+
+Or for local testing from a cloned repo:
+
+```bash
+claude --plugin-dir ./claude-code_rails-upgrade-skill
 ```
 
 ### Installation (Manual)

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ Add the marketplace and install the plugin:
 claude plugin marketplace add ombulabs/claude-code_rails-upgrade-skill
 
 # Install the plugin
-claude plugin install rails-upgrade@ombulabs-rails-upgrade
+claude plugin install rails-upgrade@fastruby-upgrade-rails
 ```
 
 Or from within Claude Code:
 
 ```
 /plugin marketplace add ombulabs/claude-code_rails-upgrade-skill
-/plugin install rails-upgrade@ombulabs-rails-upgrade
+/plugin install rails-upgrade@fastruby-upgrade-rails
 ```
 
 For local testing from a cloned repo:

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,7 +1,9 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "fastruby-upgrade-rails",
+  "version": "1.0.0",
   "metadata": {
-    "description": "Claude Code plugins for Rails upgrades by OmbuLabs.ai, based on FastRuby.io methodology."
+    "description": "Claude Code plugin for Rails upgrades by OmbuLabs.ai, based on FastRuby.io methodology."
   },
   "owner": {
     "name": "OmbuLabs.ai",
@@ -12,7 +14,13 @@
       "name": "rails-upgrade",
       "source": "./",
       "description": "Analyzes Rails applications and generates comprehensive upgrade reports with breaking changes, deprecations, and step-by-step migration guides for Rails 2.3 through 8.1. Based on FastRuby.io methodology.",
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "author": {
+        "name": "OmbuLabs.ai",
+        "url": "https://www.ombulabs.ai"
+      },
+      "category": "development",
+      "tags": ["ruby", "rails", "upgrade", "migration", "fastruby", "breaking-changes"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/plugin.json` manifest for single-command plugin installation
- Update README with plugin install instructions (`claude plugin add`)
- Keep manual installation as fallback option

Closes #9

## Test plan
- [ ] Verify `.claude-plugin/plugin.json` is valid JSON
- [ ] Verify `claude plugin add --from https://github.com/ombulabs/claude-code_rails-upgrade-skill` works
- [ ] Verify manual installation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)