### PR TITLE
Add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rails-upgrade",
-  "version": "1.0.0",
+  "version": "3.1.0",
   "description": "Plan and execute Rails version upgrades following FastRuby.io methodology",
   "skills": "./rails-upgrade/",
   "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "rails-upgrade",
+  "version": "1.0.0",
+  "description": "Plan and execute Rails version upgrades following FastRuby.io methodology",
+  "skills": "./rails-upgrade/",
+  "author": {
+    "name": "OmbuLabs",
+    "url": "https://github.com/ombulabs"
+  },
+  "repository": "https://github.com/ombulabs/claude-code_rails-upgrade-skill",
+  "license": "MIT",
+  "keywords": ["rails", "ruby", "upgrade", "migration"]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,16 @@
   },
   "repository": "https://github.com/ombulabs/claude-code_rails-upgrade-skill",
   "license": "MIT",
-  "keywords": ["ruby", "rails", "upgrade", "migration", "fastruby", "breaking-changes", "tech-debt", "deprecations", "legacy-code", "ruby-on-rails"]
+  "keywords": [
+    "ruby",
+    "rails",
+    "upgrade",
+    "migration",
+    "fastruby",
+    "breaking-changes",
+    "tech-debt",
+    "deprecations",
+    "legacy-code",
+    "ruby-on-rails"
+  ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   },
   "repository": "https://github.com/ombulabs/claude-code_rails-upgrade-skill",
   "license": "MIT",
-  "keywords": ["rails", "ruby", "upgrade", "migration"]
+  "keywords": ["ruby", "rails", "upgrade", "migration", "fastruby", "breaking-changes", "tech-debt", "deprecations", "legacy-code", "ruby-on-rails"]
 }

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ This skill depends on two companion skills: [rails-load-defaults](https://github
 
 ```bash
 claude plugin marketplace add https://github.com/ombulabs/claude-skills.git
-claude plugin install rails-upgrade@ombulabs-skills
-claude plugin install rails-load-defaults@ombulabs-skills
-claude plugin install dual-boot@ombulabs-skills
+claude plugin install rails-upgrade@ombulabs-ai
+claude plugin install rails-load-defaults@ombulabs-ai
+claude plugin install dual-boot@ombulabs-ai
 ```
 
 **Manual install:**

--- a/README.md
+++ b/README.md
@@ -29,29 +29,35 @@ We've encountered (and solved) edge cases that don't appear in any documentation
 
 This skill depends on the following skills. Install them first:
 
-**1. [rails-load-defaults skill](https://github.com/ombulabs/claude-code_rails-load-defaults-skill)** — incremental `load_defaults` verification and updates:
+**Via the OmbuLabs marketplace (recommended)** - installs all three skills at once:
+
+```bash
+claude plugin marketplace add https://github.com/ombulabs/claude-skills.git
+claude plugin install rails-upgrade@ombulabs-skills
+claude plugin install rails-load-defaults@ombulabs-skills
+claude plugin install dual-boot@ombulabs-skills
+```
+
+**Manual install:**
+
+**1. [rails-load-defaults skill](https://github.com/ombulabs/claude-code_rails-load-defaults-skill)** - incremental `load_defaults` verification and updates:
 
 ```bash
 git clone https://github.com/ombulabs/claude-code_rails-load-defaults-skill.git
-cp -r claude-code_rails-load-defaults-skill ~/.claude/skills/rails-load-defaults
+cp -r claude-code_rails-load-defaults-skill/rails-load-defaults ~/.claude/skills/
 ```
 
-**2. [dual-boot skill](https://github.com/ombulabs/claude-code_dual-boot-skill)** — dual-boot setup and management with `next_rails`:
+**2. [dual-boot skill](https://github.com/ombulabs/claude-code_dual-boot-skill)** - dual-boot setup and management with `next_rails`:
 
 ```bash
 git clone https://github.com/ombulabs/claude-code_dual-boot-skill.git
-cp -r claude-code_dual-boot-skill/dual-boot ~/.claude/skills/dual-boot
+cp -r claude-code_dual-boot-skill/dual-boot ~/.claude/skills/
 ```
 
-### Installation
-
-Add this skill to your Claude Code configuration:
+**3. This skill:**
 
 ```bash
-# Clone the repository
 git clone https://github.com/ombulabs/claude-code_rails-upgrade-skill.git
-
-# Add to your Claude Code skills directory
 cp -r claude-code_rails-upgrade-skill/rails-upgrade ~/.claude/skills/
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ We've encountered (and solved) edge cases that don't appear in any documentation
 
 ## How to Use This Skill
 
-### Prerequisites
+### Installation
 
-This skill depends on the following skills. Install them first:
+This skill depends on two companion skills: [rails-load-defaults](https://github.com/ombulabs/claude-code_rails-load-defaults-skill) and [dual-boot](https://github.com/ombulabs/claude-code_dual-boot-skill). The marketplace install handles all three.
 
-**Via the OmbuLabs marketplace (recommended)** - installs all three skills at once:
+**Via the OmbuLabs marketplace (recommended):**
 
 ```bash
 claude plugin marketplace add https://github.com/ombulabs/claude-skills.git
@@ -40,25 +40,18 @@ claude plugin install dual-boot@ombulabs-skills
 
 **Manual install:**
 
-**1. [rails-load-defaults skill](https://github.com/ombulabs/claude-code_rails-load-defaults-skill)** - incremental `load_defaults` verification and updates:
-
 ```bash
-git clone https://github.com/ombulabs/claude-code_rails-load-defaults-skill.git
-cp -r claude-code_rails-load-defaults-skill/rails-load-defaults ~/.claude/skills/
-```
-
-**2. [dual-boot skill](https://github.com/ombulabs/claude-code_dual-boot-skill)** - dual-boot setup and management with `next_rails`:
-
-```bash
-git clone https://github.com/ombulabs/claude-code_dual-boot-skill.git
-cp -r claude-code_dual-boot-skill/dual-boot ~/.claude/skills/
-```
-
-**3. This skill:**
-
-```bash
+# 1. This skill
 git clone https://github.com/ombulabs/claude-code_rails-upgrade-skill.git
 cp -r claude-code_rails-upgrade-skill/rails-upgrade ~/.claude/skills/
+
+# 2. rails-load-defaults (dependency)
+git clone https://github.com/ombulabs/claude-code_rails-load-defaults-skill.git
+cp -r claude-code_rails-load-defaults-skill/rails-load-defaults ~/.claude/skills/
+
+# 3. dual-boot (dependency)
+git clone https://github.com/ombulabs/claude-code_dual-boot-skill.git
+cp -r claude-code_dual-boot-skill/dual-boot ~/.claude/skills/
 ```
 
 ### Basic Usage


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` so this repo can be installed as a Claude Code plugin
- Uses the `skills` field to point to the existing `rails-upgrade/` directory, no file restructuring needed
- Part of the OmbuLabs skills marketplace setup (ombulabs/claude-skills)

## Context

We are setting up an OmbuLabs marketplace (`ombulabs/claude-skills`) that will reference this repo via git URL. This manifest is required for Claude Code to recognize the repo as a plugin.

## Test plan

- [ ] Install locally with `claude --plugin-dir ./` and verify `/rails-upgrade:rails-upgrade` is available
- [ ] Confirm SKILL.md is loaded correctly when the skill is invoked