### PR TITLE
Restructure SKILL.md for clearer boundaries and progressive disclosure

### DIFF
--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -3,545 +3,122 @@ name: rails-upgrade
 description: Analyzes Rails applications and generates comprehensive upgrade reports with breaking changes, deprecations, and step-by-step migration guides for Rails 2.3 through 8.1. Use when upgrading Rails applications, planning multi-hop upgrades, or querying version-specific changes. Based on FastRuby.io methodology and "The Complete Guide to Upgrade Rails" ebook.
 ---
 
-# Rails Upgrade Assistant Skill
+# Rails Upgrade Assistant
 
-## Skill Identity
-- **Name:** Rails Upgrade Assistant
-- **Purpose:** Intelligent Rails application upgrades from 2.3 through 8.1
-- **Skill Type:** Modular with external workflows and examples
-- **Upgrade Strategy:** Sequential only (no version skipping)
-- **Methodology:** Based on FastRuby.io upgrade best practices and "The Complete Guide to Upgrade Rails" ebook
-- **Attribution:** Content based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)
+Orchestrates Rails upgrades following the FastRuby.io methodology. Owns the end-to-end 7-step workflow. Delegates dual-boot and `load_defaults` work to dedicated skills.
+
+- **Strategy:** Sequential only, no version skipping
+- **Scope:** Rails 2.3 through 8.1
+- **Attribution:** "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)
 
 ---
 
 ## Dependencies
 
-- **dual-boot skill** ([github.com/ombulabs/claude-code_dual-boot-skill](https://github.com/ombulabs/claude-code_dual-boot-skill)) — Sets up and manages dual-boot environments using the `next_rails` gem. Covers setup, `NextRails.next?` code patterns, CI configuration, and post-upgrade cleanup. Must be installed for Step 2 of the upgrade workflow.
-- **rails-load-defaults skill** ([github.com/ombulabs/claude-code_rails-load-defaults-skill](https://github.com/ombulabs/claude-code_rails-load-defaults-skill)) — Handles incremental `load_defaults` updates with tiered risk assessment (Tier 1: low-risk, Tier 2: needs codebase grep, Tier 3: requires human review). Used as the final step after the Rails version upgrade is complete.
+Both must be installed:
+
+- **dual-boot** ([repo](https://github.com/ombulabs/claude-code_dual-boot-skill)) — Owns Step 2 (dual-boot setup) and all `NextRails.next?` code patterns.
+- **rails-load-defaults** ([repo](https://github.com/ombulabs/claude-code_rails-load-defaults-skill)) — Owns Step 6 (final `load_defaults` alignment).
+
+Read `references/delegation-contracts.md` when unsure which skill owns a given sub-task. Do not reimplement logic owned by a dependent skill.
 
 ---
 
-## Core Methodology (FastRuby.io Approach)
+## Core Workflow (7 Steps)
 
-This skill follows the proven FastRuby.io upgrade methodology:
+### Step 0: Verify Latest Patch — MANDATORY PRE-STEP
 
-1. **Incremental Upgrades** - Always upgrade one minor/major version at a time
-2. **Assessment First** - Understand scope before making changes
-3. **Dual-Boot Testing** - Test both versions during transition using `next_rails` gem
-4. **Test Coverage** - Ensure adequate test coverage before upgrading (aim for 80%+)
-5. **Gem Compatibility** - Check gem compatibility at each step using RailsBump
-6. **Deprecation Warnings** - Address deprecations before upgrading
-7. **Backwards Compatible Changes** - Deploy small changes to production before version bump
+- Read `Gemfile.lock` → exact current Rails version
+- Compare against latest patch for the series:
+  - EOL series (≤ 6.1): use static table in `references/multi-hop-strategy.md`
+  - Active series (≥ 7.0): query RubyGems API (commands in `references/multi-hop-strategy.md`)
+- If behind latest patch: guide user through patch upgrade + test run + deploy BEFORE any minor/major hop
+- **Why:** patch releases add deprecation warnings and bug fixes that make the next hop safer
 
-**Key Resources:**
-- **DELEGATE** to the `dual-boot` skill for dual-boot setup with `next_rails` (see Dependencies)
-- See `references/deprecation-warnings.md` for managing deprecations
-- See `references/staying-current.md` for maintaining upgrades over time
+### Step 1: Baseline Test Suite — MANDATORY
 
----
+- Run `bundle exec rspec` or `bundle exec rails test`
+- Record baseline: total, pass/fail, coverage if SimpleCov configured
+- If any test fails → STOP. Help fix before proceeding.
+- Details: `workflows/test-suite-verification-workflow.md`
 
-## CRITICAL: Dual-Boot Code Pattern with `NextRails.next?`
+### Step 2: Dual-Boot Setup — DELEGATE
 
-When proposing code fixes that must work with both the current and target Rails versions (dual-boot), **always use `NextRails.next?` from the `next_rails` gem** — never use `respond_to?` or other feature-detection patterns.
+- Delegate to `dual-boot` skill. It owns `Gemfile.next`, `next_rails`, and CI config.
+- Contract and boundaries: `references/delegation-contracts.md`
 
-**DELEGATE** to the `dual-boot` skill for:
-- Setup and initialization (`next_rails --init`, `Gemfile.next`)
-- `NextRails.next?` code patterns and examples
-- CI configuration for dual-boot testing
-- Post-upgrade cleanup (removing dual-boot branches)
+### Step 3: Breaking-Change Detection
 
-**DEPENDENCY:** Requires the [dual-boot skill](https://github.com/ombulabs/claude-code_dual-boot-skill)
+- Claude runs detection directly with Grep/Glob/Read. No script generation.
+- Patterns: `detection-scripts/patterns/rails-{VERSION}-patterns.yml`
+- Workflow: `workflows/direct-detection-workflow.md`
+- Context: `version-guides/upgrade-{FROM}-to-{TO}.md`
 
----
+### Step 4: Generate Reports
 
-## Core Workflow (7-Step Process)
+Two deliverables:
 
-### Step 0: Verify Latest Patch Version (MANDATORY PRE-STEP)
-- **CRITICAL:** Before any upgrade work begins, verify the app is on the latest patch release of its current Rails series
-- Read `Gemfile.lock` to find the exact current Rails version (e.g., `3.2.19`)
-- Compare against the latest patch for that series:
-  - **EOL series (≤ 6.1):** Use the static table in `references/multi-hop-strategy.md`
-  - **Active series (≥ 7.0):** Query the RubyGems API at runtime (see `references/multi-hop-strategy.md` for commands)
-- If the app is NOT on the latest patch:
-  - Inform user: "Your app is on Rails X.Y.Z but the latest patch is X.Y.W — you should upgrade to the latest patch first"
-  - Guide user through updating the Gemfile and running `bundle update rails`
-  - Run test suite after patch upgrade to verify nothing broke
-  - Deploy patch upgrade before proceeding with the minor/major version hop
-- If the app IS on the latest patch → Proceed to Step 1
-- **Why:** Patch releases contain security fixes, bug fixes, and additional deprecation warnings that make the next version hop safer and easier to debug
+1. **Comprehensive Upgrade Report** — breaking changes with OLD/NEW code from user's files, custom-code ⚠️ flags, migration plan
+2. **`app:update` Preview** — exact config diffs, new files, HIGH/MED/LOW impact
 
-### Step 1: Run Test Suite (MANDATORY FIRST STEP)
-- **CRITICAL:** Before any upgrade work begins, run the existing test suite
-- Claude executes `bundle exec rspec` or `bundle exec rails test` to verify baseline
-- All tests MUST pass before proceeding with any upgrade
-- If tests fail, stop and help user fix failing tests first
-- Record test count and coverage as baseline metrics
-- See `workflows/test-suite-verification-workflow.md` for details
+Workflows: `workflows/upgrade-report-workflow.md`, `workflows/app-update-preview-workflow.md`. Templates: `templates/*.md`.
 
-### Step 2: Set Up Dual-Boot with next_rails (EARLY SETUP)
-- **DELEGATE** to the `dual-boot` skill for setup and initialization
-- That skill handles:
-  - Checking if Gemfile.next already exists (to avoid duplicate next? method)
-  - Adding next_rails gem and running next_rails --init
-  - Installing dependencies for both Rails versions
-  - Configuring the Gemfile with if next? conditionals
-- **DEPENDENCY:** Requires the [dual-boot skill](https://github.com/ombulabs/claude-code_dual-boot-skill)
+### Step 5: Implement + Bump Rails
 
-### Step 3: Run Breaking Changes Detection (DIRECT)
-- **Claude runs detection checks directly** using Grep, Glob, and Read tools
-- No script generation - Claude searches the codebase in real-time
-- Finds issues with file:line references
-- Collects all findings immediately
-- See `workflows/direct-detection-workflow.md` for patterns to search
+- Fix breaking changes. Use `NextRails.next?` for dual-boot code (delegate patterns to dual-boot skill).
+- Update `Gemfile` to target version.
+- Run suite against both Rails versions during transition.
+- Deploy and verify.
 
-### Step 4: Generate Reports Based on Findings
-- **Comprehensive Upgrade Report**: Breaking changes analysis with OLD vs NEW code examples, custom code warnings with ⚠️ flags, step-by-step migration plan, testing checklist and rollback plan
-- **app:update Preview Report**: Shows exact configuration file changes (OLD vs NEW), lists new files to be created, impact assessment (HIGH/MEDIUM/LOW)
+### Step 6: Align `load_defaults` — FINAL, DELEGATE
 
-### Step 5: Implement Changes & Upgrade Rails Version
-- Fix breaking changes identified in the reports
-- Use `NextRails.next?` for code that must work with both versions (DELEGATE to dual-boot skill for patterns)
-- Update Gemfile to target Rails version
-- Run test suite against both versions during the transition
-- Deploy and verify
-
-### Step 6: Align load_defaults to New Version (FINAL STEP)
-- **DELEGATE** to the `rails-load-defaults` skill for detection and incremental update
-- That skill handles tiered, per-config updates with test runs between each change
-- This is done AFTER the Rails version upgrade is complete, as the last step
-- **DEPENDENCY:** Requires the [rails-load-defaults skill](https://github.com/ombulabs/claude-code_rails-load-defaults-skill)
+- Delegate to `rails-load-defaults`. It owns tiered incremental config migration.
+- Runs AFTER the Rails version bump is complete and deployed (or fully green in staging).
+- **Ordering rule:** never before Step 5.
 
 ---
 
-## Trigger Patterns
+## Core Methodology (FastRuby.io)
 
-Claude should activate this skill when user says:
-
-**Upgrade Requests:**
-- "Upgrade my Rails app to [version]"
-- "Help me upgrade from Rails [x] to [y]"
-- "What breaking changes are in Rails [version]?"
-- "Plan my upgrade from [x] to [y]"
-- "What Rails version am I using?"
-- "Analyze my Rails app for upgrade"
-- "Find breaking changes in my code"
-- "Check my app for Rails [version] compatibility"
-
-**Specific Report Requests:**
-- "Show me the app:update changes"
-- "Preview configuration changes for Rails [version]"
-- "Generate the upgrade report"
-- "What will change if I upgrade?"
+1. Incremental upgrades, one minor/major at a time
+2. Assessment before changes
+3. Dual-boot during transition
+4. Adequate test coverage (aim 80%+) before starting
+5. Gem compatibility checked per hop (see `references/gem-compatibility.md`)
+6. Deprecation warnings addressed before hop (see `references/deprecation-warnings.md`)
+7. Small backwards-compatible changes shipped to prod before version bump
 
 ---
 
-## CRITICAL: Sequential Upgrade Strategy
-
-### ⚠️ Version Skipping is NOT Allowed
-
-Rails upgrades MUST follow a sequential path. Examples:
-
-**For Rails 5.x to 8.x:**
-```
-5.0.x → 5.1.x → 5.2.x → 6.0.x → 6.1.x → 7.0.x → 7.1.x → 7.2.x → 8.0.x → 8.1.x
-```
-
-**You CANNOT skip versions.** Examples:
-- ❌ 5.2 → 6.1 (skips 6.0)
-- ❌ 6.0 → 7.0 (skips 6.1)
-- ❌ 7.0 → 8.0 (skips 7.1 and 7.2)
-- ✅ 5.2 → 6.0 (correct)
-- ✅ 7.0 → 7.1 (correct)
-- ✅ 7.2 → 8.0 (correct)
-
-If user requests a multi-hop upgrade (e.g., 5.2 → 8.1):
-1. Explain the sequential requirement
-2. Break it into individual hops
-3. Generate separate reports for each hop
-4. Recommend completing each hop fully before moving to next
-
----
-
-## Supported Upgrade Paths
-
-### Legacy Rails (2.3 - 4.2)
-
-| From | To | Difficulty | Key Changes | Ruby Required |
-|------|-----|-----------|-------------|---------------|
-| 2.3.x | 3.0.x | Very Hard | XSS protection, routes syntax | 1.8.7 - 1.9.3 |
-| 3.0.x | 3.1.x | Medium | Asset pipeline, jQuery | 1.8.7 - 1.9.3 |
-| 3.1.x | 3.2.x | Easy | Ruby 1.9.3 support | 1.8.7 - 2.0 |
-| 3.2.x | 4.0.x | Hard | Strong Parameters, Turbolinks | 1.9.3+ |
-| 4.0.x | 4.1.x | Medium | Spring, secrets.yml | 1.9.3+ |
-| 4.1.x | 4.2.x | Medium | ActiveJob, Web Console | 1.9.3+ |
-| 4.2.x | 5.0.x | Hard | ActionCable, API mode, ApplicationRecord | 2.2.2+ |
-
-### Modern Rails (5.0 - 8.1)
-
-| From | To | Difficulty | Key Changes | Ruby Required |
-|------|-----|-----------|-------------|---------------|
-| 5.0.x | 5.1.x | Easy | Encrypted secrets, yarn default | 2.2.2+ |
-| 5.1.x | 5.2.x | Medium | Active Storage, credentials | 2.2.2+ |
-| 5.2.x | 6.0.x | Hard | Zeitwerk, Action Mailbox/Text | 2.5.0+ |
-| 6.0.x | 6.1.x | Medium | Horizontal sharding, strict loading | 2.5.0+ |
-| 6.1.x | 7.0.x | Hard | Hotwire/Turbo, Import Maps | 2.7.0+ |
-| 7.0.x | 7.1.x | Medium | Composite keys, async queries | 2.7.0+ |
-| 7.1.x | 7.2.x | Medium | Transaction-aware jobs, DevContainers | 3.1.0+ |
-| 7.2.x | 8.0.x | Very Hard | Propshaft, Solid gems, Kamal | 3.2.0+ |
-| 8.0.x | 8.1.x | Easy | Bundler-audit, max_connections | 3.2.0+ |
-
----
-
-## Available Resources
-
-### Core Documentation
-- `SKILL.md` - This file (entry point)
-
-### Version-Specific Guides (Load as needed)
-
-**Legacy Rails:**
-- `version-guides/upgrade-3.2-to-4.0.md` - Rails 3.2 → 4.0 (Strong Parameters)
-- `version-guides/upgrade-4.2-to-5.0.md` - Rails 4.2 → 5.0 (ApplicationRecord)
-
-**Modern Rails:**
-- `version-guides/upgrade-5.0-to-5.1.md` - Rails 5.0 → 5.1 (Encrypted secrets)
-- `version-guides/upgrade-5.1-to-5.2.md` - Rails 5.1 → 5.2 (Active Storage, Credentials)
-- `version-guides/upgrade-5.2-to-6.0.md` - Rails 5.2 → 6.0 (Zeitwerk)
-- `version-guides/upgrade-6.0-to-6.1.md` - Rails 6.0 → 6.1 (Horizontal sharding)
-- `version-guides/upgrade-6.1-to-7.0.md` - Rails 6.1 → 7.0 (Hotwire/Turbo)
-- `version-guides/upgrade-7.0-to-7.1.md` - Rails 7.0 → 7.1 (Composite keys)
-- `version-guides/upgrade-7.1-to-7.2.md` - Rails 7.1 → 7.2 (Transaction jobs)
-- `version-guides/upgrade-7.2-to-8.0.md` - Rails 7.2 → 8.0 (Propshaft)
-- `version-guides/upgrade-8.0-to-8.1.md` - Rails 8.0 → 8.1 (bundler-audit)
-
-### Workflow Guides (Load when generating deliverables)
-- `workflows/test-suite-verification-workflow.md` - **MANDATORY FIRST STEP** - How to run and verify test suite
-- `workflows/direct-detection-workflow.md` - How to run breaking change detection directly
-- `workflows/upgrade-report-workflow.md` - How to generate upgrade reports
-- `workflows/app-update-preview-workflow.md` - How to generate app:update previews
-
-### Examples (Load when user needs clarification)
-- `examples/simple-upgrade.md` - Single-hop upgrade example
-- `examples/multi-hop-upgrade.md` - Multi-hop upgrade example
-
-### External Dependencies
-- **dual-boot skill** - Dual-boot setup and management with next_rails (Step 2) (https://github.com/ombulabs/claude-code_dual-boot-skill)
-- **rails-load-defaults skill** - Incremental load_defaults alignment (Step 6, final step) (https://github.com/ombulabs/claude-code_rails-load-defaults-skill)
-
-### Reference Materials
-- `references/deprecation-warnings.md` - Finding and fixing deprecations
-- `references/staying-current.md` - Keeping up with Rails releases
-- `references/breaking-changes-by-version.md` - Quick lookup
-- `references/multi-hop-strategy.md` - Multi-version planning
-- `references/testing-checklist.md` - Comprehensive testing
-- `references/gem-compatibility.md` - Common gem version requirements
-
-### Detection Pattern Resources
-- `detection-scripts/patterns/rails-*.yml` - Version-specific patterns for direct detection
-
-### Report Templates
-- `templates/upgrade-report-template.md` - Main upgrade report structure
-- `templates/app-update-preview-template.md` - Configuration preview
-
----
-
-## High-Level Workflow
-
-When user requests an upgrade, follow this workflow:
-
-### Step 0: Verify Latest Patch Version (MANDATORY PRE-STEP)
-```
-⚠️  THIS STEP IS REQUIRED BEFORE ANY OTHER WORK
-
-1. Read Gemfile.lock to find exact current Rails version (e.g., 3.2.19)
-2. Compare against latest patch for that series:
-   - EOL series (≤ 6.1): use static table in references/multi-hop-strategy.md
-   - Active series (≥ 7.0): query RubyGems API (see references/multi-hop-strategy.md for commands)
-3. If current version < latest patch:
-   - INFORM user: "Your app is on Rails X.Y.Z but the latest patch is X.Y.W"
-   - Guide through Gemfile update and bundle update rails
-   - Run test suite after patch upgrade
-   - Deploy patch upgrade before proceeding
-   - Do NOT proceed to next minor/major until on latest patch
-4. If current version == latest patch:
-   - Proceed to Step 1
-```
-
-### Step 1: Run Test Suite (MANDATORY FIRST STEP)
-```
-⚠️  THIS STEP IS REQUIRED BEFORE ANY OTHER WORK
-
-1. Read: workflows/test-suite-verification-workflow.md
-2. Detect test framework (RSpec, Minitest, or both)
-3. Run test suite with: bundle exec rspec OR bundle exec rails test
-4. Capture results: total tests, passing, failing, pending
-5. If ANY tests fail:
-   - STOP the upgrade process
-   - Report failing tests to user
-   - Offer to help fix failing tests
-   - Do NOT proceed until all tests pass
-6. If all tests pass:
-   - Record baseline metrics (test count, coverage if available)
-   - Proceed to Step 2
-```
-
-### Step 2: Set Up Dual-Boot with next_rails (EARLY SETUP)
-```
-DELEGATE to the dual-boot skill for setup and initialization.
-That skill handles:
-- Checking if Gemfile.next already exists (to avoid duplicate next? method)
-- Adding next_rails gem and running next_rails --init
-- Installing dependencies for both Rails versions
-- Configuring the Gemfile with if next? conditionals
-```
-
-### Step 3: Validate Upgrade Path
-```
-1. Check if upgrade is single-hop or multi-hop
-2. If multi-hop, explain sequential requirement
-3. Plan individual hops
-```
-
-### Step 4: Run Breaking Changes Detection (DIRECT)
-```
-Claude runs detection directly using tools - NO script generation needed
-
-1. Read: workflows/direct-detection-workflow.md
-2. Read: detection-scripts/patterns/rails-{VERSION}-patterns.yml
-3. For each pattern in the patterns file:
-   - Use Grep tool to search for the pattern
-   - Collect file paths and line numbers
-   - Store findings with context
-4. Read: version-guides/upgrade-{FROM}-to-{TO}.md for context
-5. Compile all findings into structured data
-```
-
-### Step 5: Load Report Resources & Generate Reports
-```
-1. Read: templates/upgrade-report-template.md
-2. Read: templates/app-update-preview-template.md
-3. Read: workflows/upgrade-report-workflow.md
-4. Read: workflows/app-update-preview-workflow.md
-```
-
-**Deliverable #1: Comprehensive Upgrade Report**
-- **Input:** Direct detection findings + version guide data
-- **Output:** Report with real code examples from user's project
-
-**Deliverable #2: app:update Preview**
-- **Input:** Actual config files + findings
-- **Output:** Preview with real file paths and changes
-
-### Step 6: Present Reports & Implement Changes
-```
-1. Present Comprehensive Upgrade Report first
-2. Present app:update Preview Report second
-3. Implement breaking change fixes using NextRails.next? for dual-boot code
-4. Update Gemfile to target Rails version
-5. Run test suite against both versions
-6. Deploy and verify
-```
-
-### Step 7: Align load_defaults (FINAL STEP)
-```
-⚠️  THIS STEP HAPPENS AFTER THE UPGRADE IS COMPLETE
-
-1. DELEGATE to the rails-load-defaults skill
-2. That skill walks through each config change one at a time, grouped by risk tier
-3. Tests are re-run between each change
-4. Consolidates into config/application.rb when done
-```
-
----
-
-## Pre-Upgrade Checklist (FastRuby.io Best Practices)
-
-Before starting ANY upgrade:
-
-### 1. Test Coverage Assessment (AUTOMATED - Step 1 of Workflow)
-- [x] Run test suite - all tests passing? **← Claude runs this automatically**
-- [x] Check test coverage (aim for >70%) **← Claude captures this if SimpleCov is configured**
-- [ ] Review critical paths have coverage
-
-**Note:** This step is now automated. Claude will run the test suite and BLOCK the upgrade if any tests fail.
-
-### 2. Dependency Audit
-- [ ] Run `bundle outdated`
-- [ ] Check gem compatibility with target Rails version
-- [ ] Identify gems that need upgrading first
-
-### 3. Database Backup
-- [ ] Backup production database
-- [ ] Backup development/staging databases
-- [ ] Verify backup restore process works
-
-### 4. Git Branch Strategy
-- [ ] Create upgrade branch from main/master
-- [ ] Set up CI for upgrade branch
-- [ ] Plan merge strategy
-
-### 5. Deprecation Warnings
-- [ ] Run app with `RAILS_DEPRECATION_WARNINGS=1`
-- [ ] Address existing deprecation warnings
-- [ ] Enable verbose deprecations in test environment
-
----
-
-## Common Request Patterns
-
-### Pattern 1: Full Upgrade Request
-**User says:** "Upgrade my Rails app to 8.1"
-
-**Action - Step 0 (MANDATORY: Verify Latest Patch):**
-1. Read `Gemfile.lock` for exact Rails version
-2. Compare against latest patch for that series (see `references/multi-hop-strategy.md`)
-3. If not on latest patch → Guide user through patch upgrade first
-4. If on latest patch → Proceed to Step 1
-
-**Action - Step 1 (MANDATORY: Verify Tests Pass):**
-1. Load: `workflows/test-suite-verification-workflow.md`
-2. Detect test framework (RSpec or Minitest)
-3. Run test suite: `bundle exec rspec` or `bundle exec rails test`
-4. If tests FAIL → STOP and help fix tests first
-5. If tests PASS → Record baseline and proceed
-
-**Action - Step 2 (Set Up Dual-Boot):**
-1. DELEGATE to the `dual-boot` skill for setup
-2. Set up next_rails, Gemfile.next, and dual-boot CI
-
-**Action - Step 3 (Run Detection Directly):**
-1. Validate upgrade path
-2. Load: `workflows/direct-detection-workflow.md`
-3. Load: `detection-scripts/patterns/rails-{VERSION}-patterns.yml`
-4. Use Grep/Glob/Read tools to search for each pattern
-5. Collect findings with file:line references
-
-**Action - Step 4 (Generate Reports):**
-1. Load: `workflows/upgrade-report-workflow.md`
-2. Load: `workflows/app-update-preview-workflow.md`
-3. Generate Comprehensive Upgrade Report (using direct findings)
-4. Generate app:update Preview (using actual config files)
-5. Present both reports to user
-
-**Action - Step 5 (Implement & Upgrade):**
-1. Fix breaking changes using `NextRails.next?` for dual-boot code
-2. Update Gemfile to target Rails version
-3. Run tests against both versions, deploy and verify
-
-**Action - Step 6 (Align load_defaults - FINAL):**
-1. DELEGATE to the `rails-load-defaults` skill
-2. Walk through each config incrementally after the upgrade is complete
-
-### Pattern 2: Multi-Hop Request
-**User says:** "Help me upgrade from Rails 5.2 to 8.1"
-
-**Action - Step 0 (MANDATORY: Verify Latest Patch):**
-1. Check exact current version from `Gemfile.lock`
-2. If not on latest patch of current series → Upgrade to latest patch first
-3. For multi-hop: This check applies at the START and again after each hop
-
-**Action - Step 1 (MANDATORY: Verify Tests Pass):**
-1. Run test suite BEFORE planning any upgrade work
-2. If tests fail → STOP and fix first
-3. If tests pass → Proceed with planning
-
-**Action - Step 2 (Set Up Dual-Boot):**
-1. DELEGATE to the `dual-boot` skill for setup (if not already set up)
-2. Dual-boot stays active throughout the multi-hop process
-
-**Action - Step 3 (Plan & Execute):**
-1. Explain sequential requirement
-2. Calculate hops: 5.2 → 6.0 → 6.1 → 7.0 → 7.1 → 7.2 → 8.0 → 8.1
-3. Reference: `references/multi-hop-strategy.md`
-4. Follow Pattern 1 Steps 3-5 for FIRST hop (5.2 → 6.0)
-5. After first hop complete, repeat for next hops
-6. **IMPORTANT:** After each hop, align load_defaults to the new version before starting the next hop
-
-### Pattern 3: Breaking Changes Analysis Only
-**User says:** "What breaking changes affect my app for Rails 8.0?"
-
-**Action - Step 0 (MANDATORY: Verify Latest Patch):**
-1. Check if on latest patch — warn if not, recommend patching first
-
-**Action - Step 1 (MANDATORY: Verify Tests Pass):**
-1. Run test suite first
-2. If tests fail → Warn user and recommend fixing first
-3. If tests pass → Proceed with analysis
-
-**Action - Step 2 (Run Detection):**
-1. Load: `workflows/direct-detection-workflow.md`
-2. Run detection directly using tools
-3. Present findings summary
-4. Offer to generate full upgrade report
-
----
-
-## Quality Checklist
-
-Before delivering, verify:
-
-**For Direct Detection:**
-- [ ] All patterns from version-specific YAML file checked
-- [ ] Grep/Glob tools used correctly for each pattern
-- [ ] File:line references collected for all findings
-- [ ] Context captured for each finding
-
-**For Comprehensive Upgrade Report:**
-- [ ] All {PLACEHOLDERS} replaced with actual values
-- [ ] Used ACTUAL findings from direct detection (not generic examples)
-- [ ] Breaking changes section includes real file:line references
-- [ ] Custom code warnings based on actual detected issues
-- [ ] Code examples use user's actual code from affected files
-- [ ] Next steps clearly outlined
-
-**For app:update Preview:**
-- [ ] All {PLACEHOLDERS} replaced with actual values
-- [ ] File list matches user's actual config files
-- [ ] Diffs based on real current config vs target version
-- [ ] Next steps clearly outlined
+## Conditional Loads
+
+Load on demand, not upfront:
+
+- `references/delegation-contracts.md` — when unsure which skill owns a step
+- `references/trigger-patterns.md` — when classifying the user's request type
+- `references/sequential-strategy.md` — when planning hops or validating the requested jump
+- `references/multi-hop-strategy.md` — when upgrade spans 2+ versions, or checking latest patch for a series
+- `references/gem-compatibility.md` — when assessing a specific gem against the target version
+- `references/deprecation-warnings.md` — when addressing deprecations raised in Step 1
+- `references/breaking-changes-by-version.md` — quick lookup of breaking changes by version
+- `references/testing-checklist.md` — when validating coverage before Step 1
+- `references/staying-current.md` — when user asks about keeping up post-upgrade
+- `version-guides/upgrade-X.Y-to-A.B.md` — at the start of each specific hop
+- `workflows/*.md` — when executing the corresponding step
+- `examples/*.md` — when user needs a worked example
 
 ---
 
 ## Key Principles
 
-1. **ALWAYS Verify Latest Patch First** (MANDATORY - ensure app is on latest patch of current series before any version hop)
-2. **ALWAYS Run Test Suite** (MANDATORY - no exceptions, no upgrade work until tests pass)
-3. **Block on Failing Tests** (if tests fail, STOP and help fix them before any upgrade work)
-4. **Set Up Dual-Boot Early** (dual-boot is Step 2, right after tests pass - run both versions during the entire transition)
-5. **Run Detection Directly** (use Grep/Glob/Read tools - no script generation needed)
-6. **Always Use Actual Findings** (no generic examples in reports)
-7. **Always Flag Custom Code** (with ⚠️ warnings based on detected issues)
-8. **Always Use Templates** (for consistency)
-9. **Always Check Quality** (before delivery)
-10. **Load Workflows as Needed** (don't hold everything in memory)
-11. **Sequential Process is Critical** (patch check → tests → dual-boot → detection → reports → implement → load_defaults)
-12. **Follow FastRuby.io Methodology** (incremental upgrades, assessment first)
-13. **Always Use `NextRails.next?` for Dual-Boot Code** (NEVER use `respond_to?` for version branching. DELEGATE to the `dual-boot` skill for patterns and setup.)
-14. **Align load_defaults Last** (load_defaults update happens AFTER the Rails version upgrade is complete, as the final step)
+1. Step 0 and Step 1 are mandatory gates. No exceptions.
+2. Dual-boot is Step 2, stays active through all hops in a multi-hop session.
+3. Detection runs directly with tools. No generated scripts.
+4. Reports use actual findings from user's code. No generic examples.
+5. `load_defaults` is LAST. Never mid-upgrade.
+6. Use `NextRails.next?` for dual-boot code, never `respond_to?`.
+7. Respect delegation contracts. Do not reimplement dual-boot or load_defaults logic here.
 
 ---
 
-## Success Criteria
-
-A successful upgrade assistance session:
-
-✅ **Verified latest patch version** (Step 0 - MANDATORY)
-✅ **Upgraded to latest patch if needed** (before any minor/major hop)
-✅ **Ran test suite** (Step 1 - MANDATORY)
-✅ **Verified all tests pass** (blocked if tests failed)
-✅ **Recorded baseline metrics** (test count, coverage)
-✅ **Set up dual-boot** (Step 2 - early, before upgrading)
-✅ **Ran detection directly** (using Grep/Glob/Read tools - no script)
-✅ **Generated Comprehensive Upgrade Report** using actual findings
-✅ **Generated app:update Preview** using actual config files
-✅ Used user's actual code from findings (not generic examples)
-✅ Flagged all custom code with ⚠️ warnings based on detected issues
-✅ **Implemented changes and upgraded Rails version**
-✅ **Aligned load_defaults** (final step, after upgrade is complete)
-✅ Provided clear next steps
-✅ Offered to help implement changes
-
----
-
-See [CHANGELOG.md](CHANGELOG.md) for version history and current version.
+See [CHANGELOG.md](CHANGELOG.md) for version history.

--- a/rails-upgrade/references/delegation-contracts.md
+++ b/rails-upgrade/references/delegation-contracts.md
@@ -1,0 +1,65 @@
+# Delegation Contracts
+
+Defines responsibility boundaries between `rails-upgrade` and its dependent skills. Read this when unsure which skill owns a step.
+
+## Principle
+
+`rails-upgrade` is the **orchestrator**. It drives the 7-step process end to end, but delegates bounded sub-tasks to specialist skills. Never reimplement logic owned by a dependent skill.
+
+---
+
+## Owned by `rails-upgrade`
+
+- Step 0: Latest-patch verification (`Gemfile.lock` inspection, RubyGems API, static EOL table)
+- Step 1: Baseline test suite run and pass/fail gate
+- Step 3: Breaking-change detection (Grep/Glob/Read against `detection-scripts/patterns/*.yml`)
+- Step 4: Comprehensive upgrade report + `app:update` preview generation
+- Step 5: Gemfile version bump, implementation of breaking-change fixes, post-bump test runs, deploy coordination
+- Multi-hop planning (sequence calculation, per-hop orchestration)
+- Version-specific context loaded from `version-guides/upgrade-X.Y-to-A.B.md`
+
+## Delegated to `dual-boot` skill — Step 2
+
+**Scope (dual-boot owns):**
+- Detecting existing `Gemfile.next` (avoid duplicate `next?` method definitions)
+- Installing `next_rails` gem, running `next_rails --init`
+- Generating and maintaining `Gemfile.next`
+- `NextRails.next?` code patterns for version-branching in application code
+- CI configuration for dual-boot builds
+- Post-upgrade cleanup (removing `Gemfile.next`, `NextRails.next?` branches)
+
+**Contract:**
+- **Input from rails-upgrade:** current Rails version, target Rails version
+- **Output back:** confirmation dual-boot is ready; `Gemfile` and `Gemfile.next` installed and bundling
+
+**Do NOT reimplement in rails-upgrade:**
+- Do not write `Gemfile.next` logic directly
+- Do not suggest `respond_to?` as a substitute for `NextRails.next?`
+- Do not document dual-boot CI config here — point to the dual-boot skill
+
+## Delegated to `rails-load-defaults` skill — Step 6 (FINAL)
+
+**Scope (rails-load-defaults owns):**
+- Detecting current `load_defaults` value vs target Rails version
+- Tiered config migration (Tier 1 low-risk, Tier 2 codebase-grep, Tier 3 human review)
+- Running tests between each config flip
+- Consolidation back into `config/application.rb`
+
+**Contract:**
+- **Input from rails-upgrade:** target Rails version (called AFTER version bump ships)
+- **Output back:** `load_defaults` aligned to target version, tests green
+
+**Do NOT reimplement in rails-upgrade:**
+- Do not advise flipping `load_defaults` mid-upgrade
+- Do not document per-config risk tiers here — that is the load_defaults skill's job
+
+**Ordering rule:** `load_defaults` is the LAST step. Never before the Rails version bump is in production (or at minimum fully deployed in staging and tests pass).
+
+---
+
+## Anti-patterns (do not do these)
+
+- Inlining dual-boot setup steps into the rails-upgrade workflow
+- Showing `NextRails.next?` full examples in `SKILL.md` — reference the dual-boot skill instead
+- Running `load_defaults` changes during Step 5 (implementation) — wrong phase
+- Claiming rails-upgrade can handle dual-boot or load_defaults without the dependent skill installed

--- a/rails-upgrade/references/sequential-strategy.md
+++ b/rails-upgrade/references/sequential-strategy.md
@@ -1,0 +1,60 @@
+# Sequential Upgrade Strategy
+
+Read this when planning any upgrade, especially multi-hop. Explains why version-skipping is forbidden and lists supported hops with difficulty and Ruby requirements.
+
+## Rule: No Version Skipping
+
+Rails upgrades MUST follow a sequential path, one minor/major at a time.
+
+**For Rails 5.x → 8.x:**
+```
+5.0 → 5.1 → 5.2 → 6.0 → 6.1 → 7.0 → 7.1 → 7.2 → 8.0 → 8.1
+```
+
+**Forbidden:**
+- 5.2 → 6.1 (skips 6.0)
+- 6.0 → 7.0 (skips 6.1)
+- 7.0 → 8.0 (skips 7.1, 7.2)
+
+**Allowed:**
+- 5.2 → 6.0
+- 7.0 → 7.1
+- 7.2 → 8.0
+
+When a user requests a multi-hop upgrade:
+1. Explain the sequential requirement
+2. Break into individual hops
+3. Generate separate reports per hop
+4. Recommend completing each hop fully (ship to prod) before starting the next
+
+See `reference/multi-hop-strategy.md` for per-series details (latest patches, EOL status, Ruby constraints).
+
+---
+
+## Supported Upgrade Paths
+
+### Legacy Rails (2.3 – 4.2)
+
+| From | To | Difficulty | Key Changes | Ruby Required |
+|------|-----|-----------|-------------|---------------|
+| 2.3.x | 3.0.x | Very Hard | XSS protection, routes syntax | 1.8.7 – 1.9.3 |
+| 3.0.x | 3.1.x | Medium | Asset pipeline, jQuery | 1.8.7 – 1.9.3 |
+| 3.1.x | 3.2.x | Easy | Ruby 1.9.3 support | 1.8.7 – 2.0 |
+| 3.2.x | 4.0.x | Hard | Strong Parameters, Turbolinks | 1.9.3+ |
+| 4.0.x | 4.1.x | Medium | Spring, secrets.yml | 1.9.3+ |
+| 4.1.x | 4.2.x | Medium | ActiveJob, Web Console | 1.9.3+ |
+| 4.2.x | 5.0.x | Hard | ActionCable, API mode, ApplicationRecord | 2.2.2+ |
+
+### Modern Rails (5.0 – 8.1)
+
+| From | To | Difficulty | Key Changes | Ruby Required |
+|------|-----|-----------|-------------|---------------|
+| 5.0.x | 5.1.x | Easy | Encrypted secrets, yarn default | 2.2.2+ |
+| 5.1.x | 5.2.x | Medium | Active Storage, credentials | 2.2.2+ |
+| 5.2.x | 6.0.x | Hard | Zeitwerk, Action Mailbox/Text | 2.5.0+ |
+| 6.0.x | 6.1.x | Medium | Horizontal sharding, strict loading | 2.5.0+ |
+| 6.1.x | 7.0.x | Hard | Hotwire/Turbo, Import Maps | 2.7.0+ |
+| 7.0.x | 7.1.x | Medium | Composite keys, async queries | 2.7.0+ |
+| 7.1.x | 7.2.x | Medium | Transaction-aware jobs, DevContainers | 3.1.0+ |
+| 7.2.x | 8.0.x | Very Hard | Propshaft, Solid gems, Kamal | 3.2.0+ |
+| 8.0.x | 8.1.x | Easy | Bundler-audit, max_connections | 3.2.0+ |

--- a/rails-upgrade/references/trigger-patterns.md
+++ b/rails-upgrade/references/trigger-patterns.md
@@ -1,0 +1,58 @@
+# Trigger Patterns
+
+When to activate the `rails-upgrade` skill, and which request pattern applies. Read this when classifying a user request at the start of a session.
+
+## Activation Triggers
+
+**Upgrade requests:**
+- "Upgrade my Rails app to [version]"
+- "Help me upgrade from Rails [x] to [y]"
+- "Plan my upgrade from [x] to [y]"
+- "What Rails version am I using?"
+- "Analyze my Rails app for upgrade"
+- "Check my app for Rails [version] compatibility"
+
+**Analysis-only requests:**
+- "What breaking changes are in Rails [version]?"
+- "Find breaking changes in my code"
+- "Show me the app:update changes"
+- "Preview configuration changes for Rails [version]"
+- "Generate the upgrade report"
+- "What will change if I upgrade?"
+
+---
+
+## Request Pattern → Workflow Mapping
+
+### Pattern 1: Full Upgrade (single hop)
+
+**Trigger:** "Upgrade my Rails app to X.Y"
+
+**Steps:** Full 7-step workflow (Step 0 → Step 6). No shortcuts.
+
+### Pattern 2: Multi-Hop Upgrade
+
+**Trigger:** "Upgrade from 5.2 to 8.1" (spans 2+ minor/major versions)
+
+**Steps:**
+1. Run Step 0 (latest patch check) and Step 1 (tests) ONCE at the start
+2. Run Step 2 (dual-boot setup) ONCE at the start — stays active across all hops
+3. For each hop (e.g., 5.2→6.0, 6.0→6.1, ...):
+   - Steps 3–6 in full
+   - Re-verify latest patch of the new series before the next hop
+4. Reference: `reference/sequential-strategy.md` for hop calculation
+5. Reference: `reference/multi-hop-strategy.md` for per-series strategy
+
+### Pattern 3: Breaking Changes Analysis Only
+
+**Trigger:** "What breaking changes affect my app for Rails X.Y?" (no actual upgrade requested)
+
+**Steps:** Step 0 (warn only if not on latest patch) → Step 1 (warn only if tests fail) → Step 3 (detection) → present findings. Skip Steps 2, 4–6.
+
+Offer at the end: "Want the full upgrade report and `app:update` preview?"
+
+### Pattern 4: Version Identification
+
+**Trigger:** "What Rails version am I using?"
+
+**Steps:** Read `Gemfile.lock`, report exact version + latest patch of that series. Recommend Step 0 action if behind.


### PR DESCRIPTION
## Summary

Restructure `SKILL.md` to make skill boundaries explicit and enable progressive disclosure. No methodology changes in this PR.

- `SKILL.md` trimmed from 547 → 124 lines. Keeps the canonical 7-step workflow, drops redundant restatements (`High-Level Workflow`, `Common Request Patterns`, `Pre-Upgrade Checklist`, `Quality Checklist`, `Success Criteria`) that repeated the same steps in different phrasing.
- New `reference/delegation-contracts.md` — defines what `rails-upgrade` owns vs. what is delegated to `dual-boot` (Step 2) and `rails-load-defaults` (Step 6). Includes input/output contracts and explicit anti-patterns so future edits know which skill owns which logic.
- New `reference/trigger-patterns.md` — activation triggers + request-pattern → workflow mapping (full upgrade, multi-hop, analysis-only, version identification).
- New `reference/sequential-strategy.md` — version-skipping rule and supported upgrade path tables (Legacy 2.3–4.2, Modern 5.0–8.1).
- Added a **Conditional Loads** section to `SKILL.md` telling the agent *when* to read each reference/workflow file, not just *that* it exists.

## Depends on

Blocked by PR #28 (rename `reference/` → `references/` per Agent Skills spec). After #28 merges, this branch will be rebased on top and the paths here updated to `references/`.

## Why

- `SKILL.md` was over the 500-line cap documented in `CLAUDE.md` and mixed executive summary with reference material.
- Contributors had no clear guide for where to edit what, or where the boundary with `dual-boot` / `rails-load-defaults` sits.
- Progressive disclosure: keep the entry point small, push detail into reference files, load on demand.

## Not in scope

- Issue #4 (methodology tweaks re: deprecation warnings, boot smoke tests, and incremental next-boot validation) will land in a follow-up PR on top of this structure.
- Directory rename to `references/` (plural) — done separately in PR #28.

## Test plan

- [ ] Verify `SKILL.md` frontmatter still valid (`name: rails-upgrade`, description unchanged)
- [ ] Run a manual session: ask the skill to plan an upgrade and confirm it references the new files at the right moments
- [ ] Confirm no broken internal links
