### PR TITLE
docs: add plugin-based install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,16 @@ We've encountered (and solved) edge cases that don't appear in any documentation
 
 This skill depends on two companion skills: [rails-load-defaults](https://github.com/ombulabs/claude-code_rails-load-defaults-skill) and [dual-boot](https://github.com/ombulabs/claude-code_dual-boot-skill). The marketplace install handles all three.
 
-**Via the OmbuLabs marketplace (recommended):**
+**From inside the Claude Code CLI prompt (recommended):**
+
+```
+/plugin marketplace add ombulabs/claude-skills
+/plugin install rails-upgrade@ombulabs-ai
+/plugin install rails-load-defaults@ombulabs-ai
+/plugin install dual-boot@ombulabs-ai
+```
+
+**From your terminal:**
 
 ```bash
 claude plugin marketplace add https://github.com/ombulabs/claude-skills.git


### PR DESCRIPTION
## Summary

Updates the README `Installation` section to show the new plugin-based install flows now that this skill ships via the [`ombulabs/claude-skills`](https://github.com/ombulabs/claude-skills) marketplace.

Three install paths are documented:

1. **From inside the Claude Code CLI prompt** (recommended):
   ```
   /plugin marketplace add ombulabs/claude-skills
   /plugin install <skill-name>@ombulabs-ai
   ```
2. **From your terminal:**
   ```bash
   claude plugin marketplace add https://github.com/ombulabs/claude-skills.git
   claude plugin install <skill-name>@ombulabs-ai
   ```
3. **Manual install** (kept for users who don't want the plugin system).

## Test plan

- [ ] Open README preview and confirm both code blocks render correctly
- [ ] Run `/plugin marketplace add ombulabs/claude-skills` then `/plugin install <skill-name>@ombulabs-ai` inside Claude Code
- [ ] Run the terminal equivalent and confirm install succeeds
