### PR TITLE
Add CLAUDE.md and apply no-difficulty/time convention to version guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Project conventions for Claude
+
+This file captures project-specific conventions Claude should follow when working in this repo.
+
+## Version guides (`rails-upgrade/version-guides/*.md`)
+
+- **Do NOT include "Difficulty" or "Estimated Time" in the header.** These are subjective, application-dependent, and drift out of date. Keep the header minimal: title, Ruby requirement, and the attribution line.
+- Base content on primary sources: the official Rails upgrade guide, the FastRuby.io blog, the OmbuLabs ebook chapter, and RailsDiff for the matching versions.
+- Organize breaking changes under 🔴 HIGH / 🟡 MEDIUM / 🟢 LOW priority sections.
+- Each breaking change entry should include: "What Changed", a detection pattern, and a BEFORE/AFTER fix.
+- Use `NextRails.next?` (never `respond_to?` or `Gem::Version` comparisons) in dual-boot code examples.
+
+## Detection patterns (`rails-upgrade/detection-scripts/patterns/rails-*-patterns.yml`)
+
+- File naming: `rails-{VERSION}-patterns.yml` where `{VERSION}` is the major+minor without a dot (e.g., `rails-42-patterns.yml` for Rails 4.2).
+- Organize patterns under `high_priority`, `medium_priority`, and `low_priority`.
+- Each pattern needs: `name`, `pattern` (regex), `exclude` (regex, empty string if none), `search_paths`, `explanation`, `fix`, `variable_name`.
+- Include a `dependencies` section for any bridge/compatibility gems mentioned in the guide.
+- Verify YAML parses before committing (`ruby -e "require 'yaml'; YAML.safe_load(File.read('...'))"`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,43 @@ This file captures project-specific conventions Claude should follow when workin
 - Each pattern needs: `name`, `pattern` (regex), `exclude` (regex, empty string if none), `search_paths`, `explanation`, `fix`, `variable_name`.
 - Include a `dependencies` section for any bridge/compatibility gems mentioned in the guide.
 - Verify YAML parses before committing (`ruby -e "require 'yaml'; YAML.safe_load(File.read('...'))"`).
+
+## Assigning priority (🔴 HIGH / 🟡 MEDIUM / 🟢 LOW)
+
+Priority applies to both version guide sections and detection pattern entries. Assign based on **blast radius** and **reversibility**, not on how much code typically needs to change.
+
+### 🔴 HIGH
+
+A change belongs in HIGH when at least one of these is true:
+- **Prevents boot, bundle, or test-suite startup** (e.g., a gem removed from Rails core that the app still requires; a renamed config key that raises on load).
+- **Causes runtime errors in typical code paths** (e.g., a removed method that most apps call — `update_attributes`, `deliver`, `find_all_by_*`).
+- **Required to upgrade at all** (Ruby version bump, mandatory base-class change like `ApplicationRecord`, removed DSL options that raise).
+- **Silently wrong behavior with production impact** — data loss, security regression, broken auth/CSRF, or cache key mismatches that invalidate stored data.
+
+If the user cannot complete the upgrade without addressing it, it is HIGH.
+
+### 🟡 MEDIUM
+
+A change belongs in MEDIUM when:
+- **Affects many apps but not all** (gem extractions like `responders`, test-helper changes like `assigns`/`assert_template`).
+- **Behavioral change in a commonly-used API** that usually works fine but has known edge-case breakage (HTML sanitizer output, serialized attribute nil handling, per-request CSRF tokens).
+- **Config rename or relocation** that doesn't raise but should be updated for forward compatibility.
+
+If the upgrade completes without it but a noticeable class of apps will see problems, it is MEDIUM.
+
+### 🟢 LOW
+
+A change belongs in LOW when:
+- **Opt-in or optional improvement** (Timecop → `travel_to`, Foreigner → native FKs, adopting new Gemfile defaults).
+- **Environment-specific config tweak** (`rails server` bind host, dev-only settings).
+- **Cosmetic/tooling changes** (schema.rb column ordering, .gitignore recommendations, new `bin/setup` script).
+
+If most apps will ignore it without consequence, it is LOW.
+
+### How to decide when unsure
+
+1. **Would a typical Rails app's test suite fail to run after the version bump without this fix?** → HIGH.
+2. **Would the app boot and tests run, but produce a future blocker for a noticeable class of apps?** → MEDIUM.
+3. **Would the app be unaffected unless the user opts into a new feature or runs in a specific environment?** → LOW.
+
+Priority is about **urgency during an upgrade**, not editorial weight.

--- a/rails-upgrade/version-guides/upgrade-3.2-to-4.0.md
+++ b/rails-upgrade/version-guides/upgrade-3.2-to-4.0.md
@@ -1,7 +1,5 @@
 # Rails 3.2 → 4.0 Upgrade Guide
 
-**Difficulty:** ⭐⭐⭐ Hard
-**Estimated Time:** 1-2 weeks
 **Ruby Requirement:** 1.9.3+ (2.0+ recommended)
 
 **Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)**

--- a/rails-upgrade/version-guides/upgrade-4.2-to-5.0.md
+++ b/rails-upgrade/version-guides/upgrade-4.2-to-5.0.md
@@ -1,7 +1,5 @@
 # Rails 4.2 → 5.0 Upgrade Guide
 
-**Difficulty:** ⭐⭐⭐ Hard
-**Estimated Time:** 1-2 weeks
 **Ruby Requirement:** 2.2.2+ (2.3+ recommended)
 
 **Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)**

--- a/rails-upgrade/version-guides/upgrade-5.0-to-5.1.md
+++ b/rails-upgrade/version-guides/upgrade-5.0-to-5.1.md
@@ -1,7 +1,5 @@
 # Rails 5.0 → 5.1 Upgrade Guide
 
-**Difficulty:** ⭐ Easy
-**Estimated Time:** 1-2 days
 **Ruby Requirement:** 2.2.2+ (2.4+ recommended)
 
 **Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)**

--- a/rails-upgrade/version-guides/upgrade-5.1-to-5.2.md
+++ b/rails-upgrade/version-guides/upgrade-5.1-to-5.2.md
@@ -1,7 +1,5 @@
 # Rails 5.1 → 5.2 Upgrade Guide
 
-**Difficulty:** ⭐⭐ Medium
-**Estimated Time:** 3-5 days
 **Ruby Requirement:** 2.2.2+ (2.5+ recommended)
 
 **Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)**

--- a/rails-upgrade/version-guides/upgrade-5.2-to-6.0.md
+++ b/rails-upgrade/version-guides/upgrade-5.2-to-6.0.md
@@ -1,7 +1,5 @@
 # Rails 5.2 → 6.0 Upgrade Guide
 
-**Difficulty:** ⭐⭐⭐ Hard
-**Estimated Time:** 1-2 weeks
 **Ruby Requirement:** 2.5.0+ (2.7+ recommended)
 
 ---

--- a/rails-upgrade/version-guides/upgrade-6.0-to-6.1.md
+++ b/rails-upgrade/version-guides/upgrade-6.0-to-6.1.md
@@ -1,7 +1,5 @@
 # Rails 6.0 → 6.1 Upgrade Guide
 
-**Difficulty:** ⭐⭐ Medium
-**Estimated Time:** 3-5 days
 **Ruby Requirement:** 2.5.0+ (2.7+ recommended)
 
 **Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)**

--- a/rails-upgrade/version-guides/upgrade-6.1-to-7.0.md
+++ b/rails-upgrade/version-guides/upgrade-6.1-to-7.0.md
@@ -1,7 +1,5 @@
 # Rails 6.1 → 7.0 Upgrade Guide
 
-**Difficulty:** ⭐⭐⭐ Hard
-**Estimated Time:** 1-2 weeks
 **Ruby Requirement:** 2.7.0+ (3.0+ recommended)
 
 ---

--- a/rails-upgrade/version-guides/upgrade-7.0-to-7.1.md
+++ b/rails-upgrade/version-guides/upgrade-7.0-to-7.1.md
@@ -1,7 +1,5 @@
 # Rails 7.0 → 7.1 Upgrade Guide
 
-**Difficulty:** ⭐⭐ Medium
-**Estimated Time:** 3-5 days
 **Ruby Requirement:** 2.7.0+ (3.0+ recommended)
 
 **Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)**

--- a/rails-upgrade/version-guides/upgrade-7.1-to-7.2.md
+++ b/rails-upgrade/version-guides/upgrade-7.1-to-7.2.md
@@ -1,7 +1,5 @@
 # Rails 7.1 → 7.2 Upgrade Guide
 
-**Difficulty:** ⭐⭐ Medium
-**Estimated Time:** 3-5 days
 **Ruby Requirement:** 3.1.0+ (3.2+ recommended)
 
 **Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)**

--- a/rails-upgrade/version-guides/upgrade-7.2-to-8.0.md
+++ b/rails-upgrade/version-guides/upgrade-7.2-to-8.0.md
@@ -1,7 +1,5 @@
 # Rails 7.2 → 8.0 Upgrade Guide
 
-**Difficulty:** ⭐⭐⭐⭐ Very Hard
-**Estimated Time:** 1-2 weeks
 **Ruby Requirement:** 3.2.0+ (required)
 
 ---

--- a/rails-upgrade/version-guides/upgrade-8.0-to-8.1.md
+++ b/rails-upgrade/version-guides/upgrade-8.0-to-8.1.md
@@ -1,7 +1,5 @@
 # Rails 8.0 → 8.1 Upgrade Guide
 
-**Difficulty:** ⭐ Easy
-**Estimated Time:** 1-2 days
 **Ruby Requirement:** 3.2.0+ (required)
 
 ---


### PR DESCRIPTION
## Summary

Adds a project `CLAUDE.md` that documents conventions for Claude when working in this repo, and applies one of those conventions to the existing version guides.

**Key convention:** version guides must not include `Difficulty:` or `Estimated Time:` headers. These are subjective, application-dependent, and drift out of date.

### Changes
- **New:** `CLAUDE.md` at repo root — documents version guide format, detection pattern format, and YAML validation
- **Updated:** 11 existing version guides — removed `Difficulty:` and `Estimated Time:` lines from headers; `Ruby Requirement` and source attribution lines preserved

## Test plan
- [x] `grep "Difficulty:\|Estimated Time:" rails-upgrade/version-guides/*.md` returns nothing
- [ ] Review CLAUDE.md for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)