### PR TITLE
Add Rails 4.0 → 4.1 upgrade guide and detection patterns

### DIFF
--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -204,6 +204,8 @@ If user requests a multi-hop upgrade (e.g., 5.2 → 8.1):
 
 **Legacy Rails:**
 - `version-guides/upgrade-3.2-to-4.0.md` - Rails 3.2 → 4.0 (Strong Parameters)
+- `version-guides/upgrade-4.0-to-4.1.md` - Rails 4.0 → 4.1 (Spring, secrets.yml, enums)
+- `version-guides/upgrade-4.1-to-4.2.md` - Rails 4.1 → 4.2 (ActiveJob, Web Console)
 - `version-guides/upgrade-4.2-to-5.0.md` - Rails 4.2 → 5.0 (ApplicationRecord)
 
 **Modern Rails:**

--- a/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
@@ -1,0 +1,145 @@
+version: "4.1"
+description: "Breaking change patterns for Rails 4.0 → 4.1 upgrade"
+
+breaking_changes:
+  high_priority:
+    - name: "MultiJSON usage"
+      pattern: "\\bMultiJSON\\b|require\\s+['\"]multi_json['\"]"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+        - "config/"
+        - "Gemfile"
+      explanation: "Rails 4.1 no longer depends on MultiJSON. Apps that reference it directly will fail once Rails stops pulling it in transitively"
+      fix: "Either add gem 'multi_json' to the Gemfile, or migrate to core JSON: obj.to_json and JSON.parse(str)"
+      variable_name: "MULTI_JSON"
+
+    - name: "Dynamic finders (find_all_by / find_last_by / scoped_by)"
+      pattern: "\\.(find_all_by_|find_last_by_|scoped_by_)[a-zA-Z_0-9]+"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 4.1 removed the activerecord-deprecated_finders dependency. find_all_by_*, find_last_by_*, and scoped_by_* no longer work"
+      fix: "Rewrite as where(col: value). For example: User.find_all_by_email(e) → User.where(email: e); User.find_last_by_email(e) → User.where(email: e).last. As a short-term bridge, add gem 'activerecord-deprecated_finders'"
+      variable_name: "DYNAMIC_FINDERS"
+
+    - name: "Dynamic find_or_initialize_by_* / find_or_create_by_*"
+      pattern: "\\.(find_or_initialize_by_|find_or_create_by_)[a-zA-Z_0-9]+"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 4.1 removed the *_by_<col> forms of find_or_initialize_by and find_or_create_by"
+      fix: "Use the hash form: find_or_initialize_by(col: value) / find_or_create_by(col: value)"
+      variable_name: "FIND_OR_X_BY_DYNAMIC"
+
+    - name: "return from a callback block"
+      pattern: "^\\s*(before_|after_|around_)(save|create|update|destroy|validation|commit|rollback|initialize|find|touch)\\b.*\\{[^}]*\\breturn\\b"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+        - "app/controllers/"
+        - "lib/"
+      explanation: "Rails 4.1 no longer supports returning from callbacks (including `return false`) as a way to halt the chain"
+      fix: "Replace `return false` with a bare `false` expression. In Rails 5+ this becomes `throw :abort`"
+      variable_name: "CALLBACK_RETURN"
+
+    - name: "Implicit join reference in includes+where string"
+      pattern: "\\.includes\\([^)]+\\)[^\\n]*\\.where\\(\\s*['\"][a-z_][a-z_0-9]*\\."
+      exclude: "\\.references\\(|\\.eager_load\\("
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 4.1 removed the string-parsing heuristic that auto-joined tables referenced inside a where(\"other_table.col = ?\") string after includes(...)"
+      fix: "Replace with explicit joins(:assoc) (no eager load), eager_load(:assoc) (eager loaded), or includes(:assoc).where(...).references(:assoc)"
+      variable_name: "IMPLICIT_JOIN_REFERENCES"
+
+    - name: "disable_implicit_join_references config (dead setting)"
+      pattern: "disable_implicit_join_references"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "config.active_record.disable_implicit_join_references does nothing in Rails 4.1 and emits a deprecation warning"
+      fix: "Remove config.active_record.disable_implicit_join_references from your config files"
+      variable_name: "DISABLE_IMPLICIT_JOIN_REFERENCES"
+
+  medium_priority:
+    - name: "default_scope in models"
+      pattern: "^\\s*default_scope\\b"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 4.1 chains default_scope with subsequent scopes (AND) instead of letting them override. Scopes that contradict the default can now return zero rows"
+      fix: "Audit each scope on models with default_scope. Use unscope(where: :col) or rewhere(col: value) where a scope is supposed to override the default"
+      variable_name: "DEFAULT_SCOPE"
+
+    - name: "ActiveRecord::Relation mutator calls"
+      pattern: "\\.where\\([^)]*\\)[^\\n]*\\.(compact!|map!|delete_if|reject!|select!|flatten!|sort!|uniq!)"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 4.1 removed mutator methods from ActiveRecord::Relation. Calling compact!/map!/delete_if/etc. on a Relation raises"
+      fix: "Call .to_a first, then mutate the array: records = Project.where(...).to_a; records.compact!"
+      variable_name: "RELATION_MUTATORS"
+
+    - name: "Controller test with format: :js (should use xhr)"
+      pattern: "^\\s*(get|post|put|patch|delete)\\s+:[a-z_]+[^\\n]*format:\\s*:js"
+      exclude: "\\bxhr\\b"
+      search_paths:
+        - "test/controllers/"
+        - "test/functional/"
+        - "spec/controllers/"
+      explanation: "Rails 4.1 extends CSRF protection to GET requests with JS responses. Controller tests that hit JS endpoints with the plain verb helpers now fail CSRF or skip the XHR code path"
+      fix: "Use xhr :verb, :action, params instead of verb :action, format: :js"
+      variable_name: "JS_CONTROLLER_TEST"
+
+    - name: "flash.to_hash with symbol key filters"
+      pattern: "flash\\.to_hash\\.(except|slice|values_at)\\(\\s*:"
+      exclude: ""
+      search_paths:
+        - "app/"
+      explanation: "flash.to_hash keys are strings in Rails 4.1. Filtering with symbol keys silently no-ops"
+      fix: "Use string keys: flash.to_hash.except(\"notify\") instead of flash.to_hash.except(:notify)"
+      variable_name: "FLASH_SYMBOL_KEYS"
+
+  low_priority:
+    - name: "Spring not in Gemfile"
+      pattern: "source\\s+['\"]https?://rubygems"
+      exclude: ""
+      search_paths:
+        - "Gemfile"
+      explanation: "FILE MARKER (manual review required): Rails 4.1 ships with Spring in the default Gemfile. Apps generated before 4.1 will not have it"
+      fix: "Add gem 'spring' under group :development in the Gemfile, then run `bundle exec spring binstub --all` to generate Spring-aware binstubs. Optional but recommended"
+      variable_name: "SPRING"
+
+    - name: "secrets.yml missing"
+      pattern: "Rails\\.application\\.config\\.secret_(key_base|token)"
+      exclude: ""
+      search_paths:
+        - "config/"
+        - "app/"
+      explanation: "Rails 4.1 introduces config/secrets.yml for centralized secret management via Rails.application.secrets"
+      fix: "Create config/secrets.yml with secret_key_base per environment and migrate readers from Rails.application.config.secret_key_base to Rails.application.secrets.secret_key_base"
+      variable_name: "SECRETS_YML"
+
+dependencies:
+  multi_json:
+    check: false
+    gem_name: "multi_json"
+    message: "Add to Gemfile only if the app still calls MultiJSON.dump / MultiJSON.load directly — Rails 4.1 no longer pulls it in"
+    url: "https://github.com/intridea/multi_json"
+
+  activerecord-deprecated_finders:
+    check: false
+    gem_name: "activerecord-deprecated_finders"
+    message: "Short-term bridge: restores find_all_by_*, find_last_by_*, scoped_by_*, and dynamic find_or_*_by_* finders removed from Rails 4.1"
+    url: "https://github.com/rails/activerecord-deprecated_finders"
+
+  spring:
+    check: false
+    gem_name: "spring"
+    message: "New Rails 4.1 default — application preloader that keeps the Rails environment in memory between commands"
+    url: "https://github.com/rails/spring"

--- a/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
@@ -23,15 +23,15 @@ breaking_changes:
       fix: "Use the hash form: find_or_initialize_by(col: value) / find_or_create_by(col: value)"
       variable_name: "FIND_OR_X_BY_DYNAMIC"
 
-    - name: "return from a callback block"
+    - name: "return inside inline callback block"
       pattern: "^\\s*(before_|after_|around_)(save|create|update|destroy|validation|commit|rollback|initialize|find|touch)\\b.*\\{[^}]*\\breturn\\b"
       exclude: ""
       search_paths:
         - "app/models/"
         - "app/controllers/"
         - "lib/"
-      explanation: "Rails 4.1 no longer supports returning from callbacks (including `return false`) as a way to halt the chain"
-      fix: "Replace `return false` with a bare `false` expression. In Rails 5+ this becomes `throw :abort`"
+      explanation: "Rails 4.1 raises LocalJumpError when an inline callback block uses `return`. LIMITATION: this regex only catches single-line `{ ... }` inline blocks on the same line as the callback declaration. Multi-line `{ ... }` blocks, all `do..end` blocks, and method-form callbacks (which are unaffected anyway) are not detected. A clean run does not prove the app is safe — spot-check manually"
+      fix: "Evaluate to the value instead: before_save { false if invalid_state? }. Or extract to a method where `return` is fine. In Rails 5+ the halt mechanism becomes `throw :abort`"
       variable_name: "CALLBACK_RETURN"
 
     - name: "Implicit join reference in includes+where string"
@@ -44,15 +44,6 @@ breaking_changes:
       fix: "Replace with explicit joins(:assoc) (no eager load), eager_load(:assoc) (eager loaded), or includes(:assoc).where(...).references(:assoc)"
       variable_name: "IMPLICIT_JOIN_REFERENCES"
 
-    - name: "disable_implicit_join_references config (dead setting)"
-      pattern: "disable_implicit_join_references"
-      exclude: ""
-      search_paths:
-        - "config/"
-      explanation: "config.active_record.disable_implicit_join_references does nothing in Rails 4.1 and emits a deprecation warning"
-      fix: "Remove config.active_record.disable_implicit_join_references from your config files"
-      variable_name: "DISABLE_IMPLICIT_JOIN_REFERENCES"
-
     - name: "store_accessor on json/hstore column (PG key semantics)"
       pattern: "^\\s*store_accessor\\s+:"
       exclude: ""
@@ -64,14 +55,13 @@ breaking_changes:
 
   medium_priority:
     - name: "MultiJSON usage"
-      pattern: "\\bMultiJSON\\b|require\\s+['\"]multi_json['\"]|gem\\s+['\"]multi_json['\"]"
+      pattern: "\\bMultiJSON\\b|require\\s+['\"]multi_json['\"]"
       exclude: ""
       search_paths:
         - "app/"
         - "lib/"
         - "config/"
-        - "Gemfile"
-      explanation: "Rails 4.1 no longer depends on MultiJSON. Apps that reference it directly will hit NameError once Rails stops pulling it in transitively"
+      explanation: "Rails 4.1 no longer depends on MultiJSON. Apps that reference it directly will hit NameError once Rails stops pulling it in transitively. Gemfile is intentionally excluded — `gem 'multi_json'` IS the fix, not a breaking-change signal"
       fix: "Either keep gem 'multi_json' in the Gemfile, or migrate callers to core JSON: obj.to_json and JSON.parse(str). Do NOT blindly replace with JSON.dump/JSON.load — those are unsafe for arbitrary objects"
       variable_name: "MULTI_JSON"
 
@@ -151,15 +141,15 @@ breaking_changes:
       fix: "If no match: add `gem 'spring'` under group :development in the Gemfile, then run `bundle exec spring binstub --all` to generate Spring-aware binstubs. Optional but recommended"
       variable_name: "SPRING"
 
-    - name: "secrets.yml missing"
+    - name: "Legacy secret_key_base / secret_token reads"
       pattern: "Rails\\.application\\.config\\.secret_(key_base|token)"
       exclude: ""
       search_paths:
         - "config/"
         - "app/"
-      explanation: "Rails 4.1 introduces config/secrets.yml for centralized secret management via Rails.application.secrets"
-      fix: "Create config/secrets.yml with secret_key_base per environment and migrate readers from Rails.application.config.secret_key_base to Rails.application.secrets.secret_key_base"
-      variable_name: "SECRETS_YML"
+      explanation: "Matches callers of the old Rails.application.config.secret_key_base / secret_token API. Rails 4.1 introduces config/secrets.yml exposed via Rails.application.secrets. NOTE: this is a migration-work signal based on hits; absence does NOT confirm secrets.yml is configured — grep cannot detect absence of a file"
+      fix: "Create config/secrets.yml with secret_key_base per environment, then migrate readers to Rails.application.secrets.secret_key_base. Delete the old config/initializers/secret_token.rb"
+      variable_name: "SECRET_KEY_BASE_READS"
 
     - name: "render :text usage"
       pattern: "\\brender\\s+(:text\\s*=>|text:)"
@@ -208,6 +198,15 @@ breaking_changes:
       explanation: "Rails 4.1 changed the around-callback lambda signature — the block is now a positional argument, not &block"
       fix: "Drop the ampersand: ->(r, block) { ...; block.call; ... } instead of ->(r, &block) { ...; block.call; ... }"
       variable_name: "SET_CALLBACK_AROUND"
+
+    - name: "disable_implicit_join_references config (dead setting)"
+      pattern: "disable_implicit_join_references"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "config.active_record.disable_implicit_join_references is a no-op in Rails 4.1 and emits a deprecation warning. Cosmetic cleanup only"
+      fix: "Remove config.active_record.disable_implicit_join_references from your config files"
+      variable_name: "DISABLE_IMPLICIT_JOIN_REFERENCES"
 
     - name: "ActiveRecord::Migration.check_pending! in test helper"
       pattern: "ActiveRecord::Migration\\.check_pending!"

--- a/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
@@ -3,14 +3,14 @@ description: "Breaking change patterns for Rails 4.0 → 4.1 upgrade"
 
 breaking_changes:
   high_priority:
-    - name: "Dynamic finders (find_all_by / find_last_by / scoped_by)"
-      pattern: "\\.(find_all_by_|find_last_by_|scoped_by_)[a-zA-Z_0-9]+"
-      exclude: ""
+    - name: "Dynamic finders (find_all_by / find_last_by / scoped_by / find_by)"
+      pattern: "\\.(find_all_by_|find_last_by_|scoped_by_|find_by_)[a-zA-Z_0-9]+!?"
+      exclude: "\\.find_by\\s*\\("
       search_paths:
         - "app/"
         - "lib/"
-      explanation: "Rails 4.1 removed the activerecord-deprecated_finders dependency. find_all_by_*, find_last_by_*, and scoped_by_* no longer work"
-      fix: "Rewrite as where(col: value). For example: User.find_all_by_email(e) → User.where(email: e); User.find_last_by_email(e) → User.where(email: e).last. As a short-term bridge, add gem 'activerecord-deprecated_finders'"
+      explanation: "Rails 4.1 removed the activerecord-deprecated_finders dependency. find_all_by_*, find_last_by_*, scoped_by_*, and find_by_* (including find_by_*!) no longer work"
+      fix: "Rewrite: find_all_by_* → where(col: value); find_last_by_* → where(col: value).last; scoped_by_* → where(col: value); find_by_<col> → find_by(col: value); find_by_<col>! → find_by!(col: value). As a short-term bridge, add gem 'activerecord-deprecated_finders'"
       variable_name: "DYNAMIC_FINDERS"
 
     - name: "Dynamic find_or_initialize_by_* / find_or_create_by_*"
@@ -49,9 +49,18 @@ breaking_changes:
       exclude: ""
       search_paths:
         - "app/models/"
-      explanation: "Rails 4.1 returns a string-keyed Hash (not HashWithIndifferentAccess) for PostgreSQL json/hstore columns. Direct symbol-key lookups (profile.preferences[:theme]) silently return nil"
-      fix: "Audit callers that index the column directly with symbols and switch to string keys. store_accessor-generated reader/writer methods are unaffected"
+      explanation: "Rails 4.1 returns a string-keyed Hash (not HashWithIndifferentAccess) for PostgreSQL json/hstore columns. This pattern flags models using store_accessor. It cannot detect the break directly — that requires manual audit of callers that index the underlying json/hstore column with symbol keys (e.g., record.preferences[:theme] will silently return nil instead of the value)"
+      fix: "Audit models returned by this pattern. Identify any code that indexes the json/hstore column directly with symbol keys and switch to string keys. store_accessor-generated reader/writer methods are unaffected"
       variable_name: "PG_JSON_HSTORE_KEYS"
+
+    - name: "default_scope in models"
+      pattern: "^\\s*default_scope\\b"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 4.1 chains default_scope with subsequent scopes (AND) instead of letting them override. Scopes that contradict the default can now return zero rows, silently returning no results where 4.0 would have returned data"
+      fix: "Audit each scope on models with default_scope. Use unscope(where: :col) or rewhere(col: value) where a scope is supposed to override the default"
+      variable_name: "DEFAULT_SCOPE"
 
   medium_priority:
     - name: "MultiJSON usage"
@@ -64,15 +73,6 @@ breaking_changes:
       explanation: "Rails 4.1 no longer depends on MultiJSON. Apps that reference it directly will hit NameError once Rails stops pulling it in transitively. Gemfile is intentionally excluded — `gem 'multi_json'` IS the fix, not a breaking-change signal"
       fix: "Either keep gem 'multi_json' in the Gemfile, or migrate callers to core JSON: obj.to_json and JSON.parse(str). Do NOT blindly replace with JSON.dump/JSON.load — those are unsafe for arbitrary objects"
       variable_name: "MULTI_JSON"
-
-    - name: "default_scope in models"
-      pattern: "^\\s*default_scope\\b"
-      exclude: ""
-      search_paths:
-        - "app/models/"
-      explanation: "Rails 4.1 chains default_scope with subsequent scopes (AND) instead of letting them override. Scopes that contradict the default can now return zero rows"
-      fix: "Audit each scope on models with default_scope. Use unscope(where: :col) or rewhere(col: value) where a scope is supposed to override the default"
-      variable_name: "DEFAULT_SCOPE"
 
     - name: "ActiveRecord::Relation mutator calls"
       pattern: "\\.(compact!|map!|delete_if|reject!|select!|flatten!|sort!|uniq!|collect!)\\b"
@@ -119,7 +119,7 @@ breaking_changes:
       search_paths:
         - "config/"
       explanation: "Rails 4.1 defaults enforce_available_locales to true. Any locale not in I18n.available_locales raises I18n::InvalidLocale. Presence check — ABSENCE of both settings is the signal to declare available_locales or disable enforcement"
-      fix: "If neither setting is present: declare config.i18n.available_locales = [...] in config/application.rb. Disabling enforcement (config.i18n.enforce_available_locales = false) is an escape hatch; the default exists for a security reason"
+      fix: "Audit request paths that accept a locale param from user input and validate it against an allow-list. Then declare config.i18n.available_locales = [...] in config/application.rb. Disabling enforcement (config.i18n.enforce_available_locales = false) is an escape hatch; the default exists for a security reason"
       variable_name: "I18N_ENFORCE_LOCALES"
 
     - name: "time_precision (as_json millisecond default)"
@@ -149,10 +149,10 @@ breaking_changes:
         - "app/"
       explanation: "Matches callers of the old Rails.application.config.secret_key_base / secret_token API. Rails 4.1 introduces config/secrets.yml exposed via Rails.application.secrets. NOTE: this is a migration-work signal based on hits; absence does NOT confirm secrets.yml is configured — grep cannot detect absence of a file"
       fix: "Create config/secrets.yml with secret_key_base per environment, then migrate readers to Rails.application.secrets.secret_key_base. Delete the old config/initializers/secret_token.rb"
-      variable_name: "SECRET_KEY_BASE_READS"
+      variable_name: "SECRETS_CONFIG_READS"
 
     - name: "render :text usage"
-      pattern: "\\brender\\s+(:text\\s*=>|text:)"
+      pattern: "\\brender\\s*[\\(\\s]\\s*(?:.*,\\s*)?(?:text:\\s*|:text\\s*=>)"
       exclude: ""
       search_paths:
         - "app/controllers/"

--- a/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
@@ -53,6 +53,15 @@ breaking_changes:
       fix: "Remove config.active_record.disable_implicit_join_references from your config files"
       variable_name: "DISABLE_IMPLICIT_JOIN_REFERENCES"
 
+    - name: "store_accessor on json/hstore column (PG key semantics)"
+      pattern: "^\\s*store_accessor\\s+:"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 4.1 returns a string-keyed Hash (not HashWithIndifferentAccess) for PostgreSQL json/hstore columns. Direct symbol-key lookups (profile.preferences[:theme]) silently return nil"
+      fix: "Audit callers that index the column directly with symbols and switch to string keys. store_accessor-generated reader/writer methods are unaffected"
+      variable_name: "PG_JSON_HSTORE_KEYS"
+
   medium_priority:
     - name: "MultiJSON usage"
       pattern: "\\bMultiJSON\\b|require\\s+['\"]multi_json['\"]|gem\\s+['\"]multi_json['\"]"
@@ -105,6 +114,33 @@ breaking_changes:
       fix: "Use string keys: flash.to_hash.except(\"notify\") instead of flash.to_hash.except(:notify)"
       variable_name: "FLASH_SYMBOL_KEYS"
 
+    - name: "Cookies serializer not configured"
+      pattern: "cookies_serializer"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 4.1 introduces a JSON cookies serializer. Apps generated before 4.1 keep Marshal unless they opt in. This is a presence check — ABSENCE is the signal to add config.action_dispatch.cookies_serializer = :hybrid"
+      fix: "If no match: add `Rails.application.config.action_dispatch.cookies_serializer = :hybrid` in a new config/initializers/cookies_serializer.rb. :hybrid reads legacy Marshal cookies and writes new JSON ones"
+      variable_name: "COOKIES_SERIALIZER"
+
+    - name: "I18n enforce_available_locales config"
+      pattern: "enforce_available_locales|available_locales"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 4.1 defaults enforce_available_locales to true. Any locale not in I18n.available_locales raises I18n::InvalidLocale. Presence check — ABSENCE of both settings is the signal to declare available_locales or disable enforcement"
+      fix: "If neither setting is present: declare config.i18n.available_locales = [...] in config/application.rb. Disabling enforcement (config.i18n.enforce_available_locales = false) is an escape hatch; the default exists for a security reason"
+      variable_name: "I18N_ENFORCE_LOCALES"
+
+    - name: "time_precision (as_json millisecond default)"
+      pattern: "time_precision"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 4.1 adds millisecond precision to Time/DateTime/TimeWithZone JSON output by default. Presence check — ABSENCE means the app inherits the new default and clients parsing fixed-length ISO-8601 strings may break"
+      fix: "If clients require second precision: `ActiveSupport::JSON::Encoding.time_precision = 0` in an initializer. Otherwise accept the new default"
+      variable_name: "JSON_TIME_PRECISION"
+
   low_priority:
     - name: "Spring gem in Gemfile (presence check)"
       pattern: "gem\\s+['\"]spring['\"]"
@@ -125,6 +161,64 @@ breaking_changes:
       fix: "Create config/secrets.yml with secret_key_base per environment and migrate readers from Rails.application.config.secret_key_base to Rails.application.secrets.secret_key_base"
       variable_name: "SECRETS_YML"
 
+    - name: "render :text usage"
+      pattern: "\\brender\\s+(:text\\s*=>|text:)"
+      exclude: ""
+      search_paths:
+        - "app/controllers/"
+      explanation: "render :text was security-adjacent (sent text/html). Rails 4.1 introduces render :plain / :html / :body as precise replacements and signals :text for future deprecation"
+      fix: "Replace with render plain: for text/plain, render html: for explicit HTML, or render body: for no Content-Type header"
+      variable_name: "RENDER_TEXT"
+
+    - name: "encode_json hook override"
+      pattern: "def\\s+encode_json\\b"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 4.1's rewritten JSON encoder no longer calls encode_json. Custom implementations silently become dead code"
+      fix: "Move the logic into as_json, or add gem 'activesupport-json_encoder' to restore the old encoder behavior"
+      variable_name: "ENCODE_JSON_HOOK"
+
+    - name: "encode_big_decimal_as_string (dead setting)"
+      pattern: "encode_big_decimal_as_string"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 4.1's new JSON encoder removed the BigDecimal-as-number option. The setting is a no-op"
+      fix: "Remove the setting. If clients require BigDecimal-as-number, add gem 'activesupport-json_encoder' to restore the old behavior"
+      variable_name: "BIG_DECIMAL_AS_STRING"
+
+    - name: "JSON.generate / JSON.dump on Rails objects"
+      pattern: "\\bJSON\\.(generate|dump)\\b"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 4.1 isolated its encoder from the JSON gem. JSON.generate/JSON.dump no longer honor as_json. Output of Rails objects (AR instances, TimeWithZone, etc.) may differ from 4.0"
+      fix: "Use obj.to_json for Rails semantics (honors as_json). Keep JSON.generate only when you explicitly want stdlib behavior — pass obj.as_json first if needed"
+      variable_name: "JSON_GEM_ISOLATION"
+
+    - name: "set_callback around lambda with &block"
+      pattern: "set_callback\\s+.+,\\s*:around\\s*,\\s*->\\([^)]*&block"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 4.1 changed the around-callback lambda signature — the block is now a positional argument, not &block"
+      fix: "Drop the ampersand: ->(r, block) { ...; block.call; ... } instead of ->(r, &block) { ...; block.call; ... }"
+      variable_name: "SET_CALLBACK_AROUND"
+
+    - name: "ActiveRecord::Migration.check_pending! in test helper"
+      pattern: "ActiveRecord::Migration\\.check_pending!"
+      exclude: ""
+      search_paths:
+        - "test/"
+        - "spec/"
+      explanation: "require 'test_help' runs the check automatically in Rails 4.1. The explicit call is harmless but redundant"
+      fix: "Optional: remove the line from test_helper.rb / rails_helper.rb"
+      variable_name: "CHECK_PENDING_MIGRATION"
+
 dependencies:
   multi_json:
     check: false
@@ -143,3 +237,9 @@ dependencies:
     gem_name: "spring"
     message: "New Rails 4.1 default — application preloader that keeps the Rails environment in memory between commands"
     url: "https://github.com/rails/spring"
+
+  activesupport-json_encoder:
+    check: false
+    gem_name: "activesupport-json_encoder"
+    message: "Restore pre-4.1 JSON encoder behavior: circular data-structure detection, encode_json hook, BigDecimal-as-number option"
+    url: "https://github.com/rails/activesupport-json_encoder"

--- a/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
@@ -3,18 +3,6 @@ description: "Breaking change patterns for Rails 4.0 → 4.1 upgrade"
 
 breaking_changes:
   high_priority:
-    - name: "MultiJSON usage"
-      pattern: "\\bMultiJSON\\b|require\\s+['\"]multi_json['\"]"
-      exclude: ""
-      search_paths:
-        - "app/"
-        - "lib/"
-        - "config/"
-        - "Gemfile"
-      explanation: "Rails 4.1 no longer depends on MultiJSON. Apps that reference it directly will fail once Rails stops pulling it in transitively"
-      fix: "Either add gem 'multi_json' to the Gemfile, or migrate to core JSON: obj.to_json and JSON.parse(str)"
-      variable_name: "MULTI_JSON"
-
     - name: "Dynamic finders (find_all_by / find_last_by / scoped_by)"
       pattern: "\\.(find_all_by_|find_last_by_|scoped_by_)[a-zA-Z_0-9]+"
       exclude: ""
@@ -66,6 +54,18 @@ breaking_changes:
       variable_name: "DISABLE_IMPLICIT_JOIN_REFERENCES"
 
   medium_priority:
+    - name: "MultiJSON usage"
+      pattern: "\\bMultiJSON\\b|require\\s+['\"]multi_json['\"]|gem\\s+['\"]multi_json['\"]"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+        - "config/"
+        - "Gemfile"
+      explanation: "Rails 4.1 no longer depends on MultiJSON. Apps that reference it directly will hit NameError once Rails stops pulling it in transitively"
+      fix: "Either keep gem 'multi_json' in the Gemfile, or migrate callers to core JSON: obj.to_json and JSON.parse(str). Do NOT blindly replace with JSON.dump/JSON.load — those are unsafe for arbitrary objects"
+      variable_name: "MULTI_JSON"
+
     - name: "default_scope in models"
       pattern: "^\\s*default_scope\\b"
       exclude: ""
@@ -76,12 +76,12 @@ breaking_changes:
       variable_name: "DEFAULT_SCOPE"
 
     - name: "ActiveRecord::Relation mutator calls"
-      pattern: "\\.where\\([^)]*\\)[^\\n]*\\.(compact!|map!|delete_if|reject!|select!|flatten!|sort!|uniq!)"
+      pattern: "\\.(compact!|map!|delete_if|reject!|select!|flatten!|sort!|uniq!|collect!)\\b"
       exclude: ""
       search_paths:
         - "app/"
         - "lib/"
-      explanation: "Rails 4.1 removed mutator methods from ActiveRecord::Relation. Calling compact!/map!/delete_if/etc. on a Relation raises"
+      explanation: "Rails 4.1 removed mutator methods from ActiveRecord::Relation. Calling compact!/map!/delete_if/etc. on a Relation raises NoMethodError. Some hits will be false positives on plain arrays — verify the receiver"
       fix: "Call .to_a first, then mutate the array: records = Project.where(...).to_a; records.compact!"
       variable_name: "RELATION_MUTATORS"
 
@@ -106,13 +106,13 @@ breaking_changes:
       variable_name: "FLASH_SYMBOL_KEYS"
 
   low_priority:
-    - name: "Spring not in Gemfile"
-      pattern: "source\\s+['\"]https?://rubygems"
+    - name: "Spring gem in Gemfile (presence check)"
+      pattern: "gem\\s+['\"]spring['\"]"
       exclude: ""
       search_paths:
         - "Gemfile"
-      explanation: "FILE MARKER (manual review required): Rails 4.1 ships with Spring in the default Gemfile. Apps generated before 4.1 will not have it"
-      fix: "Add gem 'spring' under group :development in the Gemfile, then run `bundle exec spring binstub --all` to generate Spring-aware binstubs. Optional but recommended"
+      explanation: "Rails 4.1 ships with Spring as a new preloader default. This is a presence check — a HIT means Spring is already configured; ABSENCE is the signal to add it. Grep cannot detect absence, so review the Gemfile manually when this pattern does not match"
+      fix: "If no match: add `gem 'spring'` under group :development in the Gemfile, then run `bundle exec spring binstub --all` to generate Spring-aware binstubs. Optional but recommended"
       variable_name: "SPRING"
 
     - name: "secrets.yml missing"

--- a/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
+++ b/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
@@ -24,37 +24,7 @@ The breaking changes are smaller than 3.2 → 4.0 but several silently change be
 
 ### 🔴 HIGH PRIORITY
 
-#### 1. MultiJSON Removed from Rails
-
-**What Changed:**
-Rails 4.1 no longer depends on [`MultiJSON`](https://github.com/intridea/multi_json). Apps that still reference it directly will fail to boot once Rails stops pulling it in transitively.
-
-**Detection Pattern:**
-```ruby
-require 'multi_json'
-MultiJSON.dump(obj)
-MultiJSON.load(str)
-```
-
-**Fix:**
-```ruby
-# Option A — keep MultiJSON
-# Gemfile
-gem 'multi_json'
-
-# Option B — migrate to core JSON
-# BEFORE
-MultiJSON.dump(obj)
-MultiJSON.load(str)
-
-# AFTER
-obj.to_json
-JSON.parse(str)
-```
-
----
-
-#### 2. Dynamic Finders Removed
+#### 1. Dynamic Finders Removed
 
 **What Changed:**
 `activerecord-deprecated_finders` was removed as a Rails dependency. `find_all_by_*`, `find_last_by_*`, `scoped_by_*`, `find_or_initialize_by_*`, and `find_or_create_by_*` no longer work out of the box.
@@ -93,19 +63,16 @@ gem 'activerecord-deprecated_finders'
 
 ---
 
-#### 3. `return` from Callbacks No Longer Allowed
+#### 2. `return` Inside Inline Callback Blocks
 
 **What Changed:**
-Returning from a callback block (including `return false`) no longer halts the callback chain as before — the behavior is deprecated and removed. Use a plain `false` expression (and note that Rails 5 replaces this with `throw :abort`).
+Using `return` inside an **inline callback block** now raises `LocalJumpError` at callback-execution time. This was never officially supported; a rewrite of `ActiveSupport::Callbacks` in 4.1 closed the accidental support.
+
+**Scope:** this affects *inline blocks only* (`before_save { return false }`). Method-form callbacks (`before_save :guard` where `guard` contains `return false`) are unaffected — `return` there behaves normally and `false` still halts the chain on 4.1.
 
 **Detection Pattern:**
 ```ruby
 before_save { return false if invalid_state? }
-before_save :maybe_halt
-
-def maybe_halt
-  return false unless ready?
-end
 ```
 
 **Fix:**
@@ -113,15 +80,24 @@ end
 # BEFORE
 before_save { return false if invalid_state? }
 
-# AFTER (Rails 4.1)
+# AFTER — evaluate to the value
 before_save { false if invalid_state? }
+
+# OR — extract to a method where `return` is fine
+before_save :halt_if_invalid
+
+def halt_if_invalid
+  return false if invalid_state?
+end
 ```
+
+Note: in Rails 5+ the halt mechanism changes again — `false` no longer halts, use `throw :abort`.
 
 See [rails/rails#13271](https://github.com/rails/rails/pull/13271).
 
 ---
 
-#### 4. Implicit Join References Removed
+#### 3. Implicit Join References Removed
 
 **What Changed:**
 `includes(...).where("other_table.col = ...")` no longer auto-joins the referenced table. The string-parsing heuristic was removed because it produced incorrect SQL in edge cases.
@@ -157,6 +133,38 @@ See [rails/rails#9712](https://github.com/rails/rails/issues/9712) for backgroun
 ---
 
 ### 🟡 MEDIUM PRIORITY
+
+#### 4. MultiJSON Removed from Rails
+
+**What Changed:**
+Rails 4.1 no longer depends on [`MultiJSON`](https://github.com/intridea/multi_json). Apps that reference `MultiJSON` directly will raise `NameError` once the transitive dependency goes away.
+
+**Detection Pattern:**
+```ruby
+require 'multi_json'
+MultiJSON.dump(obj)
+MultiJSON.load(str)
+```
+
+**Fix:**
+```ruby
+# Option A — keep MultiJSON explicitly
+# Gemfile
+gem 'multi_json'
+
+# Option B — migrate to core JSON
+# BEFORE
+MultiJSON.dump(obj)
+MultiJSON.load(str)
+
+# AFTER
+obj.to_json
+JSON.parse(str)
+```
+
+**Do not** blindly substitute `JSON.dump` / `JSON.load` — those are the `JSON` gem's arbitrary-object (de)serializers and are unsafe on untrusted input.
+
+---
 
 #### 5. `default_scope` Chains with Other Scopes
 

--- a/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
+++ b/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
@@ -2,7 +2,7 @@
 
 **Ruby Requirement:** 1.9.3+ (2.0+ recommended)
 
-**Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs), the official Rails 4.1 upgrade guide, and the Rails 4.1 release notes.**
+**Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs), the [official Rails 4.1 upgrade guide](https://guides.rubyonrails.org/v4.1/upgrading_ruby_on_rails.html#upgrading-from-rails-4-0-to-rails-4-1), and the Rails 4.1 release notes.**
 
 ---
 
@@ -16,7 +16,7 @@ Rails 4.1 is a minor release that polishes 4.0 and introduces several new featur
 - **Variants** (`request.variant = :tablet`)
 - **`Module#concerning`** API
 
-The breaking changes are smaller than 3.2 → 4.0 but several silently change behavior. MultiJSON removal, dynamic-finder removal, and implicit-join removal are the most common sources of boot/runtime failures.
+The breaking changes are smaller than 3.2 → 4.0 but several silently change behavior. Dynamic-finder removal, implicit-join removal, and PostgreSQL `json`/`hstore` key semantics are the most common sources of runtime failures.
 
 ---
 
@@ -132,9 +132,39 @@ See [rails/rails#9712](https://github.com/rails/rails/issues/9712) for backgroun
 
 ---
 
+#### 4. PostgreSQL `json` / `hstore` Columns Return String-Keyed Hashes
+
+**What Changed:**
+In 4.0, PostgreSQL `json` and `hstore` columns (and any `store_accessor` built on top of them) returned a `HashWithIndifferentAccess` — symbol and string access both worked. In 4.1 they return a plain `Hash` with **string keys only**. Symbol access silently returns `nil`.
+
+**Detection Pattern:**
+```ruby
+class Profile < ActiveRecord::Base
+  # :preferences is a json or hstore column
+  store_accessor :preferences, :theme
+end
+
+profile.preferences[:theme]   # 4.0: "dark" | 4.1: nil
+profile.preferences["theme"]  # both: "dark"
+```
+
+**Fix:**
+Use string keys consistently when reading from `json` / `hstore` attributes:
+```ruby
+# BEFORE
+profile.preferences[:theme]
+
+# AFTER
+profile.preferences["theme"]
+```
+
+`store_accessor`-generated methods (`profile.theme`) still work — the change only bites direct hash lookups. Audit serializers, presenters, and `as_json` overrides that index into these attributes.
+
+---
+
 ### 🟡 MEDIUM PRIORITY
 
-#### 4. MultiJSON Removed from Rails
+#### 5. MultiJSON Removed from Rails
 
 **What Changed:**
 Rails 4.1 no longer depends on [`MultiJSON`](https://github.com/intridea/multi_json). Apps that reference `MultiJSON` directly will raise `NameError` once the transitive dependency goes away.
@@ -166,7 +196,26 @@ JSON.parse(str)
 
 ---
 
-#### 5. `default_scope` Chains with Other Scopes
+#### 6. Cookies Serializer Opt-In (Marshal → JSON / Hybrid)
+
+**What Changed:**
+Apps created before 4.1 keep `Marshal` as the signed/encrypted cookie serializer. Rails 4.1 introduces a JSON serializer and a `:hybrid` mode that reads legacy Marshal cookies and writes new JSON ones — but the default is still `Marshal` unless you opt in.
+
+**Detection Pattern:**
+Missing initializer. No `cookies_serializer` set in `config/initializers/` or `config/application.rb`.
+
+**Fix:**
+Add an initializer to migrate transparently:
+```ruby
+# config/initializers/cookies_serializer.rb
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+```
+
+Once all live cookies have rotated, switch to `:json` for the leaner path. Note that JSON cannot round-trip arbitrary Ruby objects — `Date`/`Time` become strings, symbol keys become strings. Store primitives only in cookie-backed sessions/flash.
+
+---
+
+#### 7. `default_scope` Chains with Other Scopes
 
 **What Changed:**
 In Rails 4.1, `default_scope` conditions are now combined (ANDed) with subsequent scopes instead of being overridden by them. Scopes that intentionally contradicted the default scope now produce zero rows.
@@ -195,7 +244,7 @@ See [this commit](https://github.com/rails/rails/commit/f950b2699f97749ef706c693
 
 ---
 
-#### 6. `ActiveRecord::Relation` Mutator Methods Removed
+#### 8. `ActiveRecord::Relation` Mutator Methods Removed
 
 **What Changed:**
 `#map!`, `#delete_if`, `#compact!`, and other mutator methods are no longer delegated from `Relation` to the underlying array. Call `#to_a` first.
@@ -219,7 +268,7 @@ projects.compact!
 
 ---
 
-#### 7. CSRF Protection Now Covers GET with JS Responses
+#### 9. CSRF Protection Now Covers GET with JS Responses
 
 **What Changed:**
 GET requests with JS responses now enforce CSRF. Test helpers that issue `get` / `post :create, format: :js` must switch to `xhr` so Rails treats the request as XHR.
@@ -239,11 +288,13 @@ post :create, format: :js
 xhr :post, :create, format: :js
 ```
 
+If you legitimately want to serve JS to remote `<script>` tags, skip CSRF on that specific action.
+
 See [rails/rails#13345](https://github.com/rails/rails/pull/13345).
 
 ---
 
-#### 8. Flash Message Keys Are Strings
+#### 10. Flash Message Keys Are Strings
 
 **What Changed:**
 Keys in `flash.to_hash` are now strings, not symbols. Code that filters the hash with symbol keys silently no-ops.
@@ -263,11 +314,57 @@ flash.to_hash.except(:notify)
 flash.to_hash.except("notify")
 ```
 
+Direct access with either symbol or string still works — the break is specifically in `to_hash`-derived iteration/filtering.
+
+---
+
+#### 11. I18n Enforces Available Locales
+
+**What Changed:**
+`config.i18n.enforce_available_locales` defaults to `true` in 4.1. Any locale that is not in `I18n.available_locales` raises `I18n::InvalidLocale`. Apps that accepted user-supplied locale parameters without validation will raise on previously-accepted input.
+
+**Detection Pattern:**
+```ruby
+I18n.locale = params[:locale]  # previously accepted anything
+```
+
+**Fix:**
+Preferred — fix data and keep enforcement on. Make sure every locale the app actually uses is declared:
+```ruby
+# config/application.rb
+config.i18n.available_locales = [:en, :es, :fr]
+```
+
+Escape hatch — disable enforcement (not recommended; the default exists for a security reason):
+```ruby
+# config/application.rb
+config.i18n.enforce_available_locales = false
+```
+
+---
+
+#### 12. `as_json` Millisecond Precision for Time/DateTime/TWZ
+
+**What Changed:**
+`Time`, `DateTime`, and `ActiveSupport::TimeWithZone` serialize to JSON with millisecond precision by default (`2024-01-01T00:00:00.000Z` instead of `2024-01-01T00:00:00Z`). API clients that parse the timestamp as a fixed-length string or match it against a regex break.
+
+**Detection Pattern:**
+Contract tests or client code that expects second-precision ISO-8601 timestamps in JSON responses.
+
+**Fix:**
+Preserve 4.0 behavior globally:
+```ruby
+# config/initializers/time_precision.rb
+ActiveSupport::JSON::Encoding.time_precision = 0
+```
+
+Or update consumers to accept fractional seconds.
+
 ---
 
 ### 🟢 LOW PRIORITY
 
-#### 9. Spring Preloader (New Default)
+#### 13. Spring Preloader (New Default)
 
 **What Changed:**
 New 4.1 apps generate a `Gemfile` with `gem 'spring'` in `:development`, and a `bin/spring` binstub. Spring keeps the Rails environment in memory between commands.
@@ -283,7 +380,7 @@ Run `bundle exec spring binstub --all` to generate Spring-aware binstubs (`bin/r
 
 ---
 
-#### 10. `secrets.yml` (New)
+#### 14. `secrets.yml` (New)
 
 **What Changed:**
 Rails 4.1 introduces `config/secrets.yml` as the recommended home for `secret_key_base` and other app secrets, accessible via `Rails.application.secrets`.
@@ -299,6 +396,141 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 ```
 Migrate reads from `Rails.application.config.secret_key_base` or custom initializers into `Rails.application.secrets`.
+
+---
+
+#### 15. `render :text` Soft-Deprecated
+
+**What Changed:**
+`render :text` was a security-adjacent footgun — it sent `text/html`, so any string with markup would be interpreted by the browser. 4.1 introduces `render :plain`, `render :html`, and `render :body` as precise replacements, and signals that `:text` will be deprecated in a future release.
+
+**Detection Pattern:**
+```ruby
+render text: "ok"
+```
+
+**Fix:**
+```ruby
+# BEFORE
+render text: "ok"
+
+# AFTER — choose based on intent
+render plain: "ok"           # Content-Type: text/plain
+render html: "<b>ok</b>".html_safe  # Content-Type: text/html (explicit)
+render body: "raw"           # no Content-Type header
+```
+
+---
+
+#### 16. JSON Encoder: Removed Features
+
+**What Changed:**
+The 4.1 JSON encoder rewrite drops three features from `as_json` / `to_json`:
+- Circular data-structure detection (previously raised a clear error; now stack-overflows)
+- `encode_json(options)` hook (customized encoders must move to `as_json`)
+- Option to encode `BigDecimal` objects as numbers instead of strings
+
+**Detection Pattern:**
+```ruby
+class Money
+  def encode_json(options); "..."; end   # no longer called
+end
+
+# or code that relied on BigDecimal-as-number
+ActiveSupport.encode_big_decimal_as_string = false  # no-op on 4.1
+```
+
+**Fix:**
+Restore the old encoder as an opt-in gem:
+```ruby
+# Gemfile
+gem 'activesupport-json_encoder'
+```
+Or migrate `encode_json` implementations into `as_json`, and update clients to parse BigDecimals as strings.
+
+---
+
+#### 17. JSON Gem Isolated from Rails Encoder
+
+**What Changed:**
+`JSON.generate` / `JSON.dump` no longer consult Rails' `as_json`. They serialize arbitrary Ruby objects the way the stdlib `json` gem wants — which differs significantly. Use `obj.to_json` when you want Rails semantics.
+
+**Detection Pattern:**
+```ruby
+JSON.generate(active_record_instance)  # now returns something unexpected
+```
+
+**Fix:**
+```ruby
+# BEFORE (ambiguous intent)
+JSON.generate(obj)
+
+# AFTER — Rails semantics (honors as_json)
+obj.to_json
+
+# AFTER — stdlib semantics (if you truly wanted that)
+JSON.generate(obj.as_json)
+```
+
+---
+
+#### 18. Fixtures ERB Evaluated in a Separate Context
+
+**What Changed:**
+Each fixture's ERB template now runs in its own isolated context. Helper methods defined in one fixture (`<% def my_helper; end %>`) are no longer visible from another fixture.
+
+**Detection Pattern:**
+ERB methods defined at the top of one `.yml` fixture and called from another.
+
+**Fix:**
+Hoist helpers into a module and mix it into `ActiveRecord::FixtureSet.context_class`:
+```ruby
+# test/test_helper.rb
+module FixtureFileHelpers
+  def file_sha(path)
+    Digest::SHA2.hexdigest(File.read(Rails.root.join("test/fixtures", path)))
+  end
+end
+
+ActiveRecord::FixtureSet.context_class.send :include, FixtureFileHelpers
+```
+
+---
+
+#### 19. `ActiveSupport::Callbacks.set_callback` Around-Block Signature
+
+**What Changed:**
+The around-callback lambda signature changed from `&block` (yield-style) to a positional `block` argument.
+
+**Detection Pattern:**
+```ruby
+set_callback :save, :around, ->(r, &block) { stuff; block.call; stuff }
+```
+
+**Fix:**
+```ruby
+# BEFORE
+set_callback :save, :around, ->(r, &block) { stuff; block.call; stuff }
+
+# AFTER
+set_callback :save, :around, ->(r, block) { stuff; block.call; stuff }
+```
+
+Rare — only affects apps that build callbacks dynamically with `set_callback`.
+
+---
+
+#### 20. `ActiveRecord::Migration.check_pending!` Now Redundant in Test Helper
+
+**What Changed:**
+`require 'test_help'` now runs pending-migration checks automatically. Explicit calls to `ActiveRecord::Migration.check_pending!` in `test_helper.rb` / `rails_helper.rb` are harmless but unnecessary.
+
+**Fix (optional):**
+Remove the now-redundant line:
+```ruby
+# test/test_helper.rb — can be removed
+ActiveRecord::Migration.check_pending!
+```
 
 ---
 
@@ -320,6 +552,15 @@ Remove if present (no longer does anything):
 config.active_record.disable_implicit_join_references = true
 ```
 
+Add to opt into forward-compatible defaults:
+```ruby
+# config/initializers/cookies_serializer.rb
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+
+# config/application.rb
+config.i18n.available_locales = [:en, ...]  # or set enforce_available_locales = false
+```
+
 ---
 
 ## Migration Steps
@@ -332,7 +573,9 @@ ruby -v  # 1.9.3+ (2.0+ recommended)
 
 ### Phase 2: Pre-requisites
 1. Fix all current 4.0 deprecation warnings.
-2. Audit for `MultiJSON`, dynamic finders, implicit-join `where` strings, and `return false` callbacks.
+2. Audit for `MultiJSON`, dynamic finders, implicit-join `where` strings, and inline-block callbacks that `return`.
+3. Audit for PG `json` / `hstore` access with symbol keys.
+4. List the locales the app actually uses.
 
 ### Phase 3: Gemfile Updates
 ```ruby
@@ -344,6 +587,9 @@ gem 'rails', '~> 4.1.0'
 
 # Only if you cannot migrate dynamic finders now
 # gem 'activerecord-deprecated_finders'
+
+# Only if you depend on removed JSON encoder features
+# gem 'activesupport-json_encoder'
 
 group :development do
   gem 'spring'
@@ -363,25 +609,31 @@ Cross-check against [RailsDiff 4.0.13 → 4.1.16](http://railsdiff.org/4.0.13/4.
 
 ### Phase 5: Fix Breaking Changes
 1. Replace dynamic finders with `where(...)` / `find_or_create_by(...)` equivalents.
-2. Replace `return false` in callbacks with a bare `false` expression.
+2. Move `return` out of inline callback blocks (or refactor to a method).
 3. Replace implicit-join `where` strings with `joins`, `eager_load`, or `references`.
-4. Swap `post :x, format: :js` for `xhr :post, :x, format: :js` in controller tests.
-5. Update `flash.to_hash` callers to use string keys.
-6. Review `default_scope`-bearing models for broken combinations; apply `unscope`/`rewhere`.
-7. Convert `Relation.compact!` / `Relation.map!` etc. to `to_a` then mutate.
-8. Remove any `MultiJSON` usage or add it back to the `Gemfile` explicitly.
+4. Audit PG `json` / `hstore` access: use string keys.
+5. Add the cookies serializer initializer (`:hybrid`).
+6. Declare `config.i18n.available_locales` or disable enforcement.
+7. Swap `post :x, format: :js` for `xhr :post, :x, format: :js` in controller tests.
+8. Update `flash.to_hash` callers to use string keys.
+9. Review `default_scope`-bearing models; apply `unscope`/`rewhere`.
+10. Convert `Relation.compact!` / `Relation.map!` etc. to `to_a` then mutate.
+11. Replace `render :text` with `:plain` / `:html` / `:body`.
+12. Pin JSON time precision if clients need it (`time_precision = 0`).
+13. Remove MultiJSON usage or add it back to the `Gemfile` explicitly.
 
 ### Phase 6: Testing
 - Run full test suite.
 - Exercise controller specs that hit JS endpoints.
 - Exercise models with `default_scope` and `after_*` callbacks.
-- Verify flash-based UI.
+- Verify flash-based UI and any cookie-backed session flows.
+- Exercise JSON API endpoints for timestamp format and PG `json` / `hstore` response shape.
 
 ---
 
 ## Common Issues
 
-### Issue: App fails to boot with `NameError: uninitialized constant MultiJSON`
+### Issue: App fails with `NameError: uninitialized constant MultiJSON`
 
 **Cause:** MultiJSON no longer pulled in by Rails.
 
@@ -391,7 +643,7 @@ Cross-check against [RailsDiff 4.0.13 → 4.1.16](http://railsdiff.org/4.0.13/4.
 
 **Cause:** Dynamic finders removed.
 
-**Fix:** Rewrite as `where(email: email)` (see §2) or add `gem 'activerecord-deprecated_finders'` temporarily.
+**Fix:** Rewrite as `where(email: email)` or add `gem 'activerecord-deprecated_finders'` temporarily.
 
 ### Issue: Query returns zero rows after upgrade
 
@@ -411,6 +663,24 @@ Cross-check against [RailsDiff 4.0.13 → 4.1.16](http://railsdiff.org/4.0.13/4.
 
 **Fix:** Use `"notice"` instead of `:notice`.
 
+### Issue: `profile.preferences[:theme]` returns `nil` after upgrade
+
+**Cause:** PG `json` / `hstore` columns return string-keyed `Hash`, not `HashWithIndifferentAccess`.
+
+**Fix:** Index with string keys (`profile.preferences["theme"]`) or use the `store_accessor`-generated method.
+
+### Issue: `I18n::InvalidLocale` raised by a request that worked on 4.0
+
+**Cause:** `enforce_available_locales` is now `true` by default.
+
+**Fix:** Add the locale to `config.i18n.available_locales`, or disable enforcement if you have a strong reason.
+
+### Issue: API clients fail to parse `2024-01-01T00:00:00.000Z`
+
+**Cause:** JSON millisecond precision is on by default.
+
+**Fix:** `ActiveSupport::JSON::Encoding.time_precision = 0`, or update consumers.
+
 ---
 
 ## Resources
@@ -419,4 +689,5 @@ Cross-check against [RailsDiff 4.0.13 → 4.1.16](http://railsdiff.org/4.0.13/4.
 - [Upgrading from Rails 4.0 to Rails 4.1 (official)](https://guides.rubyonrails.org/v4.1/upgrading_ruby_on_rails.html#upgrading-from-rails-4-0-to-rails-4-1)
 - [RailsDiff 4.0.13 → 4.1.16](http://railsdiff.org/4.0.13/4.1.16)
 - [`activerecord-deprecated_finders` gem](https://github.com/rails/activerecord-deprecated_finders)
+- [`activesupport-json_encoder` gem](https://github.com/rails/activesupport-json_encoder)
 - [Running `rails:update`](http://thomasleecopeland.com/2015/08/06/running-rails-update.html)

--- a/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
+++ b/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
@@ -290,6 +290,8 @@ xhr :post, :create, format: :js
 
 If you legitimately want to serve JS to remote `<script>` tags, skip CSRF on that specific action.
 
+Forward-compat note: the `xhr :verb, :action, ...` syntax is itself removed in Rails 5.0. The 5.0 replacement is `verb :action, params: {...}, xhr: true` (or `process :action, method: :verb, xhr: true`). You will revisit these test calls in the 4.2 → 5.0 hop.
+
 See [rails/rails#13345](https://github.com/rails/rails/pull/13345).
 
 ---
@@ -580,7 +582,7 @@ ruby -v  # 1.9.3+ (2.0+ recommended)
 ### Phase 3: Gemfile Updates
 ```ruby
 # Gemfile
-gem 'rails', '~> 4.1.0'
+gem 'rails', '~> 4.1.16'  # pin to the last 4.1 patch
 
 # Only if you rely on it directly
 # gem 'multi_json'

--- a/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
+++ b/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
@@ -132,10 +132,10 @@ See [rails/rails#9712](https://github.com/rails/rails/issues/9712) for backgroun
 
 ---
 
-#### 4. PostgreSQL `json` / `hstore` Columns Return String-Keyed Hashes
+#### 4. PostgreSQL `json` / `hstore` / `array` Columns Return String-Keyed Data
 
 **What Changed:**
-In 4.0, PostgreSQL `json` and `hstore` columns (and any `store_accessor` built on top of them) returned a `HashWithIndifferentAccess` — symbol and string access both worked. In 4.1 they return a plain `Hash` with **string keys only**. Symbol access silently returns `nil`.
+In 4.0, PostgreSQL `json`, `hstore`, and `array` columns (and any `store_accessor` built on top of them) returned a `HashWithIndifferentAccess` or `ArrayWithIndifferentAccess` — symbol and string access both worked. In 4.1 they return plain `Hash` or `Array` with **string keys only**. Symbol access silently returns `nil`.
 
 **Detection Pattern:**
 ```ruby

--- a/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
+++ b/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
@@ -1,0 +1,414 @@
+# Rails 4.0 → 4.1 Upgrade Guide
+
+**Ruby Requirement:** 1.9.3+ (2.0+ recommended)
+
+**Based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs), the official Rails 4.1 upgrade guide, and the Rails 4.1 release notes.**
+
+---
+
+## Overview
+
+Rails 4.1 is a minor release that polishes 4.0 and introduces several new features:
+- **Spring** application preloader (new default)
+- **`secrets.yml`** for centralized secret/credential management
+- **Action Mailer previews** (browser-viewable emails in development)
+- **ActiveRecord enums** (`enum status: [...]`)
+- **Variants** (`request.variant = :tablet`)
+- **`Module#concerning`** API
+
+The breaking changes are smaller than 3.2 → 4.0 but several silently change behavior. MultiJSON removal, dynamic-finder removal, and implicit-join removal are the most common sources of boot/runtime failures.
+
+---
+
+## Breaking Changes
+
+### 🔴 HIGH PRIORITY
+
+#### 1. MultiJSON Removed from Rails
+
+**What Changed:**
+Rails 4.1 no longer depends on [`MultiJSON`](https://github.com/intridea/multi_json). Apps that still reference it directly will fail to boot once Rails stops pulling it in transitively.
+
+**Detection Pattern:**
+```ruby
+require 'multi_json'
+MultiJSON.dump(obj)
+MultiJSON.load(str)
+```
+
+**Fix:**
+```ruby
+# Option A — keep MultiJSON
+# Gemfile
+gem 'multi_json'
+
+# Option B — migrate to core JSON
+# BEFORE
+MultiJSON.dump(obj)
+MultiJSON.load(str)
+
+# AFTER
+obj.to_json
+JSON.parse(str)
+```
+
+---
+
+#### 2. Dynamic Finders Removed
+
+**What Changed:**
+`activerecord-deprecated_finders` was removed as a Rails dependency. `find_all_by_*`, `find_last_by_*`, `scoped_by_*`, `find_or_initialize_by_*`, and `find_or_create_by_*` no longer work out of the box.
+
+**Detection Pattern:**
+```ruby
+User.find_all_by_email(email)
+User.find_last_by_email(email)
+User.scoped_by_status("active")
+User.find_or_initialize_by_email(email)
+User.find_or_create_by_email(email)
+```
+
+**Fix:**
+```ruby
+# BEFORE
+User.find_all_by_email(email)
+User.find_last_by_email(email)
+User.scoped_by_status("active")
+User.find_or_initialize_by_email_and_name(email, name)
+User.find_or_create_by_email(email)
+
+# AFTER
+User.where(email: email)
+User.where(email: email).last
+User.where(status: "active")
+User.find_or_initialize_by(email: email, name: name)
+User.find_or_create_by(email: email)
+```
+
+If you cannot migrate callers now, restore the bridge gem:
+```ruby
+# Gemfile
+gem 'activerecord-deprecated_finders'
+```
+
+---
+
+#### 3. `return` from Callbacks No Longer Allowed
+
+**What Changed:**
+Returning from a callback block (including `return false`) no longer halts the callback chain as before — the behavior is deprecated and removed. Use a plain `false` expression (and note that Rails 5 replaces this with `throw :abort`).
+
+**Detection Pattern:**
+```ruby
+before_save { return false if invalid_state? }
+before_save :maybe_halt
+
+def maybe_halt
+  return false unless ready?
+end
+```
+
+**Fix:**
+```ruby
+# BEFORE
+before_save { return false if invalid_state? }
+
+# AFTER (Rails 4.1)
+before_save { false if invalid_state? }
+```
+
+See [rails/rails#13271](https://github.com/rails/rails/pull/13271).
+
+---
+
+#### 4. Implicit Join References Removed
+
+**What Changed:**
+`includes(...).where("other_table.col = ...")` no longer auto-joins the referenced table. The string-parsing heuristic was removed because it produced incorrect SQL in edge cases.
+
+**Detection Pattern:**
+```ruby
+Post.includes(:comments).where("comments.title = ?", "foo")
+```
+
+**Fix:**
+```ruby
+# BEFORE
+Post.includes(:comments).where("comments.title = ?", "foo")
+
+# AFTER — explicit join (no eager load)
+Post.joins(:comments).where("comments.title = ?", "foo")
+
+# AFTER — eager load
+Post.eager_load(:comments).where("comments.title = ?", "foo")
+
+# AFTER — equivalent with includes + references
+Post.includes(:comments).where("comments.title = ?", "foo").references(:comments)
+```
+
+If you see this warning:
+```
+DEPRECATION WARNING: Implicit join references were removed with Rails 4.1. Make sure to remove this configuration because it does nothing.
+```
+remove `config.active_record.disable_implicit_join_references` from your config.
+
+See [rails/rails#9712](https://github.com/rails/rails/issues/9712) for background.
+
+---
+
+### 🟡 MEDIUM PRIORITY
+
+#### 5. `default_scope` Chains with Other Scopes
+
+**What Changed:**
+In Rails 4.1, `default_scope` conditions are now combined (ANDed) with subsequent scopes instead of being overridden by them. Scopes that intentionally contradicted the default scope now produce zero rows.
+
+**Detection Pattern:**
+```ruby
+class User < ActiveRecord::Base
+  default_scope { where(active: true) }
+  scope :inactive, -> { where(active: false) }
+end
+
+# Rails 4.0:  SELECT ... WHERE active = false
+# Rails 4.1:  SELECT ... WHERE active = true AND active = false
+User.inactive
+```
+
+**Fix:**
+Use `unscoped`, `unscope(...)`, or the new `rewhere` method:
+```ruby
+scope :inactive, -> { unscope(where: :active).where(active: false) }
+# or
+scope :inactive, -> { rewhere(active: false) }
+```
+
+See [this commit](https://github.com/rails/rails/commit/f950b2699f97749ef706c6939a84dfc85f0b05f2).
+
+---
+
+#### 6. `ActiveRecord::Relation` Mutator Methods Removed
+
+**What Changed:**
+`#map!`, `#delete_if`, `#compact!`, and other mutator methods are no longer delegated from `Relation` to the underlying array. Call `#to_a` first.
+
+**Detection Pattern:**
+```ruby
+Project.where(title: "Rails Upgrade").compact!
+Project.where(...).map! { |p| ... }
+Project.where(...).delete_if { |p| ... }
+```
+
+**Fix:**
+```ruby
+# BEFORE
+Project.where(name: "Rails Upgrade").compact!
+
+# AFTER
+projects = Project.where(name: "Rails Upgrade").to_a
+projects.compact!
+```
+
+---
+
+#### 7. CSRF Protection Now Covers GET with JS Responses
+
+**What Changed:**
+GET requests with JS responses now enforce CSRF. Test helpers that issue `get` / `post :create, format: :js` must switch to `xhr` so Rails treats the request as XHR.
+
+**Detection Pattern:**
+```ruby
+post :create, format: :js
+get :index, format: :js
+```
+
+**Fix:**
+```ruby
+# BEFORE
+post :create, format: :js
+
+# AFTER
+xhr :post, :create, format: :js
+```
+
+See [rails/rails#13345](https://github.com/rails/rails/pull/13345).
+
+---
+
+#### 8. Flash Message Keys Are Strings
+
+**What Changed:**
+Keys in `flash.to_hash` are now strings, not symbols. Code that filters the hash with symbol keys silently no-ops.
+
+**Detection Pattern:**
+```ruby
+flash.to_hash.except(:notify)
+flash.to_hash.slice(:alert, :notice)
+```
+
+**Fix:**
+```ruby
+# BEFORE
+flash.to_hash.except(:notify)
+
+# AFTER
+flash.to_hash.except("notify")
+```
+
+---
+
+### 🟢 LOW PRIORITY
+
+#### 9. Spring Preloader (New Default)
+
+**What Changed:**
+New 4.1 apps generate a `Gemfile` with `gem 'spring'` in `:development`, and a `bin/spring` binstub. Spring keeps the Rails environment in memory between commands.
+
+**Fix (optional):**
+```ruby
+# Gemfile
+group :development do
+  gem 'spring'
+end
+```
+Run `bundle exec spring binstub --all` to generate Spring-aware binstubs (`bin/rails`, `bin/rake`, etc.).
+
+---
+
+#### 10. `secrets.yml` (New)
+
+**What Changed:**
+Rails 4.1 introduces `config/secrets.yml` as the recommended home for `secret_key_base` and other app secrets, accessible via `Rails.application.secrets`.
+
+**Fix (optional):**
+Create `config/secrets.yml`:
+```yaml
+development:
+  secret_key_base: <dev key>
+test:
+  secret_key_base: <test key>
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+```
+Migrate reads from `Rails.application.config.secret_key_base` or custom initializers into `Rails.application.secrets`.
+
+---
+
+## New Features Worth Adopting
+
+- **Action Mailer previews** — subclass `ActionMailer::Preview` in `test/mailers/previews/` and browse at `/rails/mailers`.
+- **ActiveRecord enums** — `enum status: [:active, :archived]` generates scopes and predicate methods.
+- **Variants** — `request.variant = :tablet` lets views render `show.html+tablet.erb`.
+- **`Module#concerning`** — inline concerns inside a class.
+
+---
+
+## Configuration File Changes
+
+Run `bin/rake rails:update` to walk through config changes interactively. See also [RailsDiff 4.0.13 → 4.1.16](http://railsdiff.org/4.0.13/4.1.16) for the exact diff.
+
+Remove if present (no longer does anything):
+```ruby
+config.active_record.disable_implicit_join_references = true
+```
+
+---
+
+## Migration Steps
+
+### Phase 1: Preparation
+```bash
+git checkout -b rails-41-upgrade
+ruby -v  # 1.9.3+ (2.0+ recommended)
+```
+
+### Phase 2: Pre-requisites
+1. Fix all current 4.0 deprecation warnings.
+2. Audit for `MultiJSON`, dynamic finders, implicit-join `where` strings, and `return false` callbacks.
+
+### Phase 3: Gemfile Updates
+```ruby
+# Gemfile
+gem 'rails', '~> 4.1.0'
+
+# Only if you rely on it directly
+# gem 'multi_json'
+
+# Only if you cannot migrate dynamic finders now
+# gem 'activerecord-deprecated_finders'
+
+group :development do
+  gem 'spring'
+end
+```
+
+```bash
+bundle update rails
+```
+
+### Phase 4: Configuration
+```bash
+bin/rake rails:update
+```
+
+Cross-check against [RailsDiff 4.0.13 → 4.1.16](http://railsdiff.org/4.0.13/4.1.16).
+
+### Phase 5: Fix Breaking Changes
+1. Replace dynamic finders with `where(...)` / `find_or_create_by(...)` equivalents.
+2. Replace `return false` in callbacks with a bare `false` expression.
+3. Replace implicit-join `where` strings with `joins`, `eager_load`, or `references`.
+4. Swap `post :x, format: :js` for `xhr :post, :x, format: :js` in controller tests.
+5. Update `flash.to_hash` callers to use string keys.
+6. Review `default_scope`-bearing models for broken combinations; apply `unscope`/`rewhere`.
+7. Convert `Relation.compact!` / `Relation.map!` etc. to `to_a` then mutate.
+8. Remove any `MultiJSON` usage or add it back to the `Gemfile` explicitly.
+
+### Phase 6: Testing
+- Run full test suite.
+- Exercise controller specs that hit JS endpoints.
+- Exercise models with `default_scope` and `after_*` callbacks.
+- Verify flash-based UI.
+
+---
+
+## Common Issues
+
+### Issue: App fails to boot with `NameError: uninitialized constant MultiJSON`
+
+**Cause:** MultiJSON no longer pulled in by Rails.
+
+**Fix:** Add `gem 'multi_json'` to the Gemfile, or migrate to `to_json` / `JSON.parse`.
+
+### Issue: `NoMethodError: undefined method 'find_all_by_email'`
+
+**Cause:** Dynamic finders removed.
+
+**Fix:** Rewrite as `where(email: email)` (see §2) or add `gem 'activerecord-deprecated_finders'` temporarily.
+
+### Issue: Query returns zero rows after upgrade
+
+**Cause:** A scope intended to override `default_scope` is now ANDed with it.
+
+**Fix:** Use `unscope(where: :col)` or `rewhere(col: ...)`.
+
+### Issue: Controller tests raise `ActionController::InvalidAuthenticityToken` on JS endpoints
+
+**Cause:** CSRF now applies to GET + JS.
+
+**Fix:** Use `xhr :verb, :action, ...` instead of `verb :action, format: :js`.
+
+### Issue: `flash.to_hash.except(:notice)` silently keeps `:notice`
+
+**Cause:** Flash keys are strings now.
+
+**Fix:** Use `"notice"` instead of `:notice`.
+
+---
+
+## Resources
+
+- [Rails 4.1 Release Notes](https://guides.rubyonrails.org/v4.1/4_1_release_notes.html)
+- [Upgrading from Rails 4.0 to Rails 4.1 (official)](https://guides.rubyonrails.org/v4.1/upgrading_ruby_on_rails.html#upgrading-from-rails-4-0-to-rails-4-1)
+- [RailsDiff 4.0.13 → 4.1.16](http://railsdiff.org/4.0.13/4.1.16)
+- [`activerecord-deprecated_finders` gem](https://github.com/rails/activerecord-deprecated_finders)
+- [Running `rails:update`](http://thomasleecopeland.com/2015/08/06/running-rails-update.html)


### PR DESCRIPTION
## Summary

Closes #20.

- `version-guides/upgrade-4.0-to-4.1.md` — based on the OmbuLabs ebook chapter (`from-4-0-to-4-1.md`), the [official Rails 4.1 upgrade guide](https://guides.rubyonrails.org/v4.1/upgrading_ruby_on_rails.html#upgrading-from-rails-4-0-to-rails-4-1), and the 4.1 release notes. 20 breaking-change entries across HIGH/MEDIUM/LOW.
- `detection-scripts/patterns/rails-41-patterns.yml` — 22 matching detection patterns. YAML parses clean.
- `SKILL.md` — lists the new 4.0 → 4.1 guide (and the pre-existing 4.1 → 4.2 guide that was missing from the same list — see inline comment).

## Priority notes

- **MultiJSON → 🟡 MEDIUM** — not a hard boot break; raises `NameError` on first use and only affects apps that reference `MultiJSON` directly.
- **`return` in callbacks → 🔴 HIGH but inline-block only** — official docs confirm this raises `LocalJumpError` only for inline blocks; method-form callbacks with `return false` still work on 4.1. Scope is called out explicitly in the guide.
- **PG `json` / `hstore` string-keyed Hash → 🔴 HIGH** — silent runtime breakage for apps using these columns with symbol-key access.
- **`default_scope` chaining → 🟡 MEDIUM (tentative)** — candidate for HIGH per the CLAUDE.md "silently wrong behavior with production impact" rubric. Left at MEDIUM for now because it only hits apps that use `default_scope` in a contradicting way. Open to bumping.

## Coverage beyond the ebook chapter

The ebook chapter covers the AR/JSON/callback basics. The following items are additionally covered from the official 4.0 → 4.1 upgrade guide:

**HIGH**
- PostgreSQL `json` / `hstore` columns return string-keyed `Hash` (not `HashWithIndifferentAccess`)

**MEDIUM**
- Cookies serializer opt-in (Marshal → `:hybrid` / JSON)
- I18n `enforce_available_locales` defaults to `true`
- `as_json` millisecond precision for `Time` / `DateTime` / `TimeWithZone`

**LOW**
- `render :text` soft-deprecated in favor of `:plain` / `:html` / `:body`
- JSON encoder feature removals (circular detection, `encode_json` hook, BigDecimal-as-number) → `activesupport-json_encoder` gem
- JSON gem isolation from the Rails encoder (`JSON.generate` no longer honors `as_json`)
- Fixture ERB evaluated in a separate context (helpers via `ActiveRecord::FixtureSet.context_class`)
- `ActiveSupport::Callbacks.set_callback` around-block signature change
- Test helper `ActiveRecord::Migration.check_pending!` now redundant

## Test plan

- [x] `ruby -e "require 'yaml'; YAML.safe_load_file('rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml')"` succeeds
- [ ] Manual smoke: run the detection on a Rails 4.0 app and confirm the HIGH-priority patterns (dynamic finders, implicit join, inline-block callback return, PG json/hstore `store_accessor`) fire where expected
- [ ] Cross-check against RailsDiff 4.0.13 → 4.1.16 for anything missed
