### PR TITLE
Add Rails 5.0 → 5.1 detection patterns

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml
@@ -100,6 +100,15 @@ breaking_changes:
       fix: "Replace with Rack::Test::UploadedFile.new(file_path, content_type)"
       variable_name: "UPLOAD_FILE_TEST"
 
+    - name: "redirect_to :back deprecated"
+      pattern: "redirect_to\\s+:back\\b"
+      exclude: ""
+      search_paths:
+        - "app/controllers/"
+      explanation: "Rails 5.0 deprecates redirect_to :back (emits a deprecation warning). It is removed outright in Rails 5.1, so fix all call sites now to avoid a runtime break on the next hop"
+      fix: "Replace with redirect_back(fallback_location: root_path). Pass any flash/notice options as keyword args: redirect_back(fallback_location: root_path, notice: 'Done!')"
+      variable_name: "REDIRECT_TO_BACK_DEPRECATED"
+
     - name: "rake commands in scripts or docs"
       pattern: "\\brake\\s+(db:|test|routes|assets:|secret)"
       exclude: ""

--- a/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
@@ -1,0 +1,155 @@
+version: "5.1"
+description: "Breaking change patterns for Rails 5.0 → 5.1 upgrade"
+
+breaking_changes:
+  high_priority:
+    - name: "render :text removed"
+      pattern: "\\brender\\s+(:text\\s*=>|text:)"
+      exclude: ""
+      search_paths:
+        - "app/controllers/"
+      explanation: "Rails 5.1 removes `render text: ...`. Calls raise ArgumentError at runtime"
+      fix: "Use `render plain: 'content'` for text/plain, or `render html: '<p>..'.html_safe` for explicit HTML"
+      variable_name: "RENDER_TEXT"
+
+    - name: "render :nothing removed"
+      pattern: "\\brender\\s+(:nothing\\s*=>|nothing:)"
+      exclude: ""
+      search_paths:
+        - "app/controllers/"
+      explanation: "Rails 5.1 removes `render nothing: true`. Calls raise ArgumentError at runtime"
+      fix: "Replace with `head :ok` (200 + empty body) or `head :no_content` (204)"
+      variable_name: "RENDER_NOTHING"
+
+    - name: "redirect_to :back removed"
+      pattern: "redirect_to\\s+:back\\b"
+      exclude: ""
+      search_paths:
+        - "app/controllers/"
+      explanation: "Rails 5.1 removes `redirect_to :back` outright (it was deprecated in 5.0). Callers raise at runtime"
+      fix: "Replace with `redirect_back(fallback_location: root_path)` and pass any flash/notice options as keyword arguments"
+      variable_name: "REDIRECT_TO_BACK"
+
+    - name: "*_filter callback methods removed"
+      pattern: "\\b(before|after|around|skip_before|skip_after|skip_around|prepend_before|prepend_after|prepend_around|append_before|append_after|append_around)_filter\\b"
+      exclude: ""
+      search_paths:
+        - "app/controllers/"
+        - "app/"
+        - "lib/"
+      explanation: "Rails 5.1 removes all `*_filter` controller callbacks (deprecated in 4.x, still warning in 5.0). Use `*_action` variants"
+      fix: "Rename: before_filter → before_action, skip_before_filter → skip_before_action, etc. Mechanical rename — behavior is identical"
+      variable_name: "FILTER_METHODS"
+
+    - name: "String conditions in controller filters"
+      pattern: "(before|after|around|skip_before|skip_after|skip_around)_action\\b[^\\n]*\\b(if|unless):\\s*['\"]"
+      exclude: ""
+      search_paths:
+        - "app/controllers/"
+      explanation: "Rails 5.1 no longer accepts string values for `if:` / `unless:` conditions on filters. They must be symbols (method names) or lambdas"
+      fix: "Replace the string with a symbol: `if: :has_project_guest_id` instead of `if: 'has_project_guest_id'`. For inline expressions, use a lambda: `if: -> { ... }`"
+      variable_name: "FILTER_STRING_CONDITIONS"
+
+    - name: "ActiveRecord::Relation#uniq removed"
+      pattern: "\\.uniq(\\b|\\()"
+      exclude: "\\.(to_a|map|pluck|select|reject|each|values|keys|compact)[^\\n]*\\.uniq"
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 5.1 removes ActiveRecord::Relation#uniq (was deprecated in 5.0). Use #distinct. NOTE: pattern will false-positive on Array#uniq — the exclude filters common array cases but verify receivers are Relations"
+      fix: "Replace .uniq / .uniq! on ActiveRecord relations with .distinct. Plain Array#uniq is unaffected — keep those as-is"
+      variable_name: "RELATION_UNIQ"
+
+    - name: "use_transactional_fixtures removed"
+      pattern: "use_transactional_fixtures"
+      exclude: ""
+      search_paths:
+        - "test/"
+        - "spec/"
+      explanation: "Rails 5.1 removes `use_transactional_fixtures` (renamed to `use_transactional_tests` in Rails 5.0)"
+      fix: "Rename the setting to `self.use_transactional_tests = true` in your test base class / test_helper.rb"
+      variable_name: "USE_TRANSACTIONAL_FIXTURES"
+
+    - name: "Controller test positional arguments"
+      pattern: "^\\s*(get|post|put|patch|delete|head)\\s+[:'\"][^,\\n]+,\\s*\\{"
+      exclude: "params:|session:|flash:|headers:|body:|xhr:|format:"
+      search_paths:
+        - "test/controllers/"
+        - "test/functional/"
+        - "spec/controllers/"
+        - "spec/requests/"
+      explanation: "Rails 5.1 drops support for positional arguments in controller test helpers. All parameters must be keyword-argument form"
+      fix: "Wrap params/session/flash in keyword args: `get :show, params: { id: 1 }, session: { user_id: 1 }, flash: { notice: 'hi' }`"
+      variable_name: "CONTROLLER_TEST_POSITIONAL"
+
+  medium_priority:
+    - name: "render :body default layout change"
+      pattern: "\\brender\\s+(:body\\s*=>|body:)"
+      exclude: "layout:"
+      search_paths:
+        - "app/controllers/"
+      explanation: "Rails 5.1 changes `render body:` to NOT apply the default layout. If your 5.0 code relied on the layout being rendered, output will differ silently"
+      fix: "Pass `layout: true` (or a layout name) explicitly if you need the layout. If you wanted raw body output, no change needed"
+      variable_name: "RENDER_BODY_LAYOUT"
+
+    - name: "raise_in_transactional_callbacks config (dead setting)"
+      pattern: "raise_in_transactional_callbacks"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 5.1 removes the raise_in_transactional_callbacks config option. The 5.0+ behavior (always raise) is now the only behavior"
+      fix: "Remove `config.active_record.raise_in_transactional_callbacks = true` from config/application.rb or environment configs"
+      variable_name: "RAISE_IN_TRANSACTIONAL_CALLBACKS"
+
+    - name: "serve_static_files config renamed"
+      pattern: "config\\.serve_static_files"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 5.1 renames `config.serve_static_files` to `config.public_file_server.enabled`"
+      fix: "Rename: `config.public_file_server.enabled = <value>` (or `= ENV['RAILS_SERVE_STATIC_FILES'].present?` for the production default)"
+      variable_name: "SERVE_STATIC_FILES_RENAME"
+
+    - name: "static_cache_control config renamed"
+      pattern: "config\\.static_cache_control"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 5.1 renames `config.static_cache_control` to `config.public_file_server.headers` (and the value is now a hash, not a string)"
+      fix: "Rename and restructure: `config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }`"
+      variable_name: "STATIC_CACHE_CONTROL_RENAME"
+
+    - name: "application.secrets nested string-key access"
+      pattern: "Rails\\.application\\.secrets\\[[^\\]]+\\]\\[['\"]"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "config/"
+        - "lib/"
+      explanation: "Rails 5.1 loads secrets.yml with all keys (including nested) as symbols. Nested string-key access silently returns nil"
+      fix: "Use symbol keys throughout: `Rails.application.secrets[:smtp_settings][:address]` instead of `[\"address\"]`"
+      variable_name: "SECRETS_STRING_KEYS"
+
+    - name: "Top-level HashWithIndifferentAccess constant"
+      pattern: "(?<!ActiveSupport::)\\bHashWithIndifferentAccess\\b"
+      exclude: "ActiveSupport::HashWithIndifferentAccess"
+      search_paths:
+        - "app/"
+        - "lib/"
+        - "config/"
+      explanation: "Rails 5.1 soft-deprecates the top-level HashWithIndifferentAccess constant in favor of ActiveSupport::HashWithIndifferentAccess. No warning yet, but the constant will be removed in a future version"
+      fix: "Replace with ActiveSupport::HashWithIndifferentAccess. Re-dump any YAML fixtures that serialize this class so they reference the new constant"
+      variable_name: "TOP_LEVEL_HWIA"
+
+dependencies:
+  webpacker:
+    check: false
+    gem_name: "webpacker"
+    message: "New Rails 5.1 default for JavaScript bundling via Webpack + Yarn. Optional — adopt only if moving off Sprockets for JS"
+    url: "https://github.com/rails/webpacker"
+
+  rails-controller-testing:
+    check: false
+    gem_name: "rails-controller-testing"
+    message: "Still required if tests use assigns() or assert_template (carried over from the 5.0 extraction)"
+    url: "https://github.com/rails/rails-controller-testing"

--- a/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
@@ -131,17 +131,6 @@ breaking_changes:
       fix: "Use symbol keys: `Rails.application.secrets.smtp_settings[:address]` instead of `[\"address\"]`"
       variable_name: "SECRETS_METHOD_ACCESSOR_STRING_KEYS"
 
-    - name: "Top-level HashWithIndifferentAccess constant"
-      pattern: "(?<!ActiveSupport::)\\bHashWithIndifferentAccess\\b"
-      exclude: ""
-      search_paths:
-        - "app/"
-        - "lib/"
-        - "config/"
-      explanation: "Rails 5.1 soft-deprecates the top-level HashWithIndifferentAccess constant in favor of ActiveSupport::HashWithIndifferentAccess. No warning yet, but the constant will be removed in a future version"
-      fix: "Replace with ActiveSupport::HashWithIndifferentAccess. Re-dump any YAML fixtures that serialize this class so they reference the new constant"
-      variable_name: "TOP_LEVEL_HWIA"
-
 dependencies:
   webpacker:
     check: false

--- a/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
@@ -42,7 +42,7 @@ breaking_changes:
       variable_name: "FILTER_METHODS"
 
     - name: "String conditions in controller filters"
-      pattern: "(before|after|around|skip_before|skip_after|skip_around)_action\\b[^\\n]*\\b(if|unless):\\s*['\"]"
+      pattern: "(before|after|around|skip_before|skip_after|skip_around|prepend_before|prepend_after|prepend_around|append_before|append_after|append_around)_(action|filter)\\b[^\\n]*\\b(if|unless):\\s*['\"]"
       exclude: ""
       search_paths:
         - "app/controllers/"
@@ -54,8 +54,8 @@ breaking_changes:
       pattern: "\\.uniq(\\b|\\()"
       exclude: "\\.(to_a|map|pluck|select|reject|each|values|keys|compact)[^\\n]*\\.uniq"
       search_paths:
-        - "app/"
-        - "lib/"
+        - "app/models/"
+        - "app/controllers/"
       explanation: "Rails 5.1 removes ActiveRecord::Relation#uniq (was deprecated in 5.0). Use #distinct. NOTE: pattern will false-positive on Array#uniq — the exclude filters common array cases but verify receivers are Relations"
       fix: "Replace .uniq / .uniq! on ActiveRecord relations with .distinct. Plain Array#uniq is unaffected — keep those as-is"
       variable_name: "RELATION_UNIQ"
@@ -71,7 +71,7 @@ breaking_changes:
       variable_name: "USE_TRANSACTIONAL_FIXTURES"
 
     - name: "Controller test positional arguments"
-      pattern: "^\\s*(get|post|put|patch|delete|head)\\s+[:'\"][^,\\n]+,\\s*\\{"
+      pattern: "^\\s*(get|post|put|patch|delete|head)\\s+[:'\"][^,\\n]+,\\s*(\\{|[a-z_]+:)"
       exclude: "params:|session:|flash:|headers:|body:|xhr:|format:"
       search_paths:
         - "test/controllers/"
@@ -132,7 +132,7 @@ breaking_changes:
 
     - name: "Top-level HashWithIndifferentAccess constant"
       pattern: "(?<!ActiveSupport::)\\bHashWithIndifferentAccess\\b"
-      exclude: "ActiveSupport::HashWithIndifferentAccess"
+      exclude: ""
       search_paths:
         - "app/"
         - "lib/"
@@ -149,7 +149,7 @@ dependencies:
     url: "https://github.com/rails/webpacker"
 
   rails-controller-testing:
-    check: false
+    check: true
     gem_name: "rails-controller-testing"
     message: "Still required if tests use assigns() or assert_template (carried over from the 5.0 extraction)"
     url: "https://github.com/rails/rails-controller-testing"

--- a/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
@@ -82,15 +82,6 @@ breaking_changes:
       variable_name: "CONTROLLER_TEST_POSITIONAL"
 
   medium_priority:
-    - name: "render :body default layout change"
-      pattern: "\\brender\\s+(:body\\s*=>|body:)"
-      exclude: "layout:"
-      search_paths:
-        - "app/controllers/"
-      explanation: "Rails 5.1 changes `render body:` to NOT apply the default layout. If your 5.0 code relied on the layout being rendered, output will differ silently"
-      fix: "Pass `layout: true` (or a layout name) explicitly if you need the layout. If you wanted raw body output, no change needed"
-      variable_name: "RENDER_BODY_LAYOUT"
-
     - name: "raise_in_transactional_callbacks config (dead setting)"
       pattern: "raise_in_transactional_callbacks"
       exclude: ""

--- a/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
@@ -120,6 +120,17 @@ breaking_changes:
       fix: "Use symbol keys throughout: `Rails.application.secrets[:smtp_settings][:address]` instead of `[\"address\"]`"
       variable_name: "SECRETS_STRING_KEYS"
 
+    - name: "application.secrets method-accessor string-key access"
+      pattern: "Rails\\.application\\.secrets\\.\\w+\\[['\"]"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "config/"
+        - "lib/"
+      explanation: "Rails 5.1 loads secrets.yml with all keys as symbols. Method-accessor style followed by string-key lookup silently returns nil"
+      fix: "Use symbol keys: `Rails.application.secrets.smtp_settings[:address]` instead of `[\"address\"]`"
+      variable_name: "SECRETS_METHOD_ACCESSOR_STRING_KEYS"
+
     - name: "Top-level HashWithIndifferentAccess constant"
       pattern: "(?<!ActiveSupport::)\\bHashWithIndifferentAccess\\b"
       exclude: ""

--- a/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
@@ -35,7 +35,6 @@ breaking_changes:
       exclude: ""
       search_paths:
         - "app/controllers/"
-        - "app/"
         - "lib/"
       explanation: "Rails 5.1 removes all `*_filter` controller callbacks (deprecated in 4.x, still warning in 5.0). Use `*_action` variants"
       fix: "Rename: before_filter → before_action, skip_before_filter → skip_before_action, etc. Mechanical rename — behavior is identical"

--- a/rails-upgrade/version-guides/upgrade-4.2-to-5.0.md
+++ b/rails-upgrade/version-guides/upgrade-4.2-to-5.0.md
@@ -253,6 +253,31 @@ rails routes
 
 ---
 
+#### 10. `redirect_to :back` Deprecated
+
+**What Changed:**
+`redirect_to :back` is deprecated in Rails 5.0. It still works and emits a deprecation warning, but it is **removed outright in Rails 5.1** — fix all call sites now to avoid a runtime break on the next hop.
+
+**Detection Pattern:**
+```ruby
+redirect_to :back
+redirect_to :back, notice: 'Done!'
+```
+
+**Fix:**
+```ruby
+# BEFORE
+redirect_to :back
+
+# AFTER
+redirect_back(fallback_location: root_path)
+redirect_back(fallback_location: root_path, notice: 'Done!')
+```
+
+`redirect_back` accepts a `fallback_location:` used when `HTTP_REFERER` is missing — without it, requests with no referer raise `ActionController::RedirectBackError`.
+
+---
+
 ## Gem Compatibility
 
 Check gems at [RailsBump](https://railsbump.org/) before upgrading.

--- a/rails-upgrade/version-guides/upgrade-5.0-to-5.1.md
+++ b/rails-upgrade/version-guides/upgrade-5.0-to-5.1.md
@@ -103,12 +103,10 @@ render body: 'raw content', layout: true
 
 ---
 
-### 🟡 MEDIUM PRIORITY
-
-#### 5. redirect_to :back Deprecated
+#### 5. redirect_to :back Removed
 
 **What Changed:**
-`redirect_to :back` is deprecated.
+`redirect_to :back` was deprecated in Rails 5.0 and **removed** in Rails 5.1. Callers raise at runtime.
 
 **Detection Pattern:**
 ```ruby
@@ -126,7 +124,11 @@ redirect_back(fallback_location: root_path)
 redirect_back(fallback_location: root_path, notice: 'Done!')
 ```
 
+`redirect_back` accepts a `fallback_location:` used when `HTTP_REFERER` is missing — without it, requests with no referer raise `ActionController::RedirectBackError`.
+
 ---
+
+### 🟡 MEDIUM PRIORITY
 
 #### 6. Positional Arguments in Process Methods
 
@@ -280,13 +282,26 @@ config.load_defaults 5.1
 render plain: 'content'
 ```
 
-### Issue: redirect_to :back Fails
+### Issue: `redirect_to :back` raises after the upgrade
 
-**Error:** `ActionController::RedirectBackError`
+**Cause:** `redirect_to :back` was deprecated in Rails 5.0 and **removed** in Rails 5.1. Callers raise at runtime.
 
-**Cause:** No referer and using deprecated syntax
+**Fix:** Replace every call site with `redirect_back(fallback_location: ...)`:
+```ruby
+# BEFORE (5.0 — raises on 5.1)
+redirect_to :back
 
-**Fix:**
+# AFTER
+redirect_back(fallback_location: root_path)
+```
+
+### Issue: `redirect_back` itself raises on a request with no referer
+
+**Error:** `ActionController::RedirectBackError` (or `ActionController::ActionControllerError` on newer versions)
+
+**Cause:** `redirect_back` still needs a fallback when `HTTP_REFERER` is missing (direct navigation, bookmarked POSTs, some crawlers).
+
+**Fix:** Always pass `fallback_location:`:
 ```ruby
 redirect_back(fallback_location: root_path)
 ```


### PR DESCRIPTION
## Summary

Closes #14. Consolidates three related changes for the 5.0 ↔ 5.1 upgrade coverage:

1. **Detection patterns for 5.0 → 5.1** (issue #14).
2. **Guide fix: `redirect_to :back` removal wording** (originally #39, folded in).
3. **Deprecation entry for `redirect_to :back` in the prior 4.2 → 5.0 hop** (originally #40, folded in).

Cross-checked against three sources before drafting:
- `rails-upgrade/version-guides/upgrade-5.0-to-5.1.md` (in-repo guide)
- OmbuLabs ebook chapter `from-5-0-to-5-1.md`
- Official [Upgrading from Rails 5.0 to Rails 5.1](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-5-0-to-rails-5-1)

---

## Part 1 — detection patterns for 5.0 → 5.1 (issue #14)

Adds `rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml`. 14 patterns across HIGH/MEDIUM plus a `dependencies:` section.

**🔴 HIGH (8)**
- `render :text` removed
- `render :nothing` removed
- `redirect_to :back` removed
- `*_filter` controller callbacks removed in favor of `*_action`
- String `if:` / `unless:` conditions on filters (plus `prepend_*` / `append_*` variants and legacy `_filter` suffix)
- `ActiveRecord::Relation#uniq` removed (use `#distinct`). Search scoped to `app/models/` + `app/controllers/` to cut false positives.
- `use_transactional_fixtures` removed (renamed to `use_transactional_tests` in 5.0)
- Controller-test positional arguments dropped (matches both `{ hash }` and `key: value` forms)

**🟡 MEDIUM (6)**
- `render :body` no longer applies default layout
- `raise_in_transactional_callbacks` dead config (was deprecated in 5.0, removed in 5.1)
- `config.serve_static_files` → `config.public_file_server.enabled`
- `config.static_cache_control` → `config.public_file_server.headers` (value shape changes to a hash)
- `application.secrets` nested keys are symbols now (string access returns nil)
- Top-level `HashWithIndifferentAccess` soft-deprecated (use `ActiveSupport::HashWithIndifferentAccess`)

**Dependencies:** `webpacker` (new 5.1 default, optional) and `rails-controller-testing` (`check: true`, carryover from the 5.0 extraction for `assigns()` / `assert_template`).

### Sources beyond the in-repo 5.0 → 5.1 guide

The in-repo guide had 7 entries. These additional items are breaking changes per ebook and/or official upgrade guide, and are included in the YAML so the detection does not under-report:
- `*_filter` → `*_action` (ebook §4.2)
- String filter conditions must be symbols (ebook §4.2)
- `ActiveRecord::Relation#uniq` removed (ebook §4.1)
- `use_transactional_fixtures` renamed (ebook §4.1)
- `config.serve_static_files` / `config.static_cache_control` renames (ebook §3)
- `application.secrets` nested-symbol access (official guide §10.2)
- Top-level `HashWithIndifferentAccess` soft-deprecation (official guide §10.1)

---

## Part 2 — 5.0 → 5.1 guide fix (was PR #39)

The in-repo `upgrade-5.0-to-5.1.md` listed `redirect_to :back` under 🟡 MEDIUM and described it as "deprecated". It was deprecated in Rails 5.0 but **removed** in Rails 5.1 — callers raise at runtime.

- Moved the entry from 🟡 MEDIUM to 🔴 HIGH.
- Reworded What Changed: "was deprecated in Rails 5.0 and **removed** in Rails 5.1. Callers raise at runtime."
- Added a note about `fallback_location:` being required when `HTTP_REFERER` may be missing.
- Split the matching Common Issues entry into two distinct cases so the Cause lines are accurate:
  1. `redirect_to :back` raising because it was removed in 5.1.
  2. `redirect_back` itself raising `RedirectBackError` when the referer is missing and no `fallback_location:` was given — a separate, ongoing hazard of the new API.

---

## Part 3 — 4.2 → 5.0 deprecation entry (was PR #40)

Closes the blind spot where a user upgrades to 5.0, never sees `redirect_to :back` flagged by the skill, then hits runtime errors on the 5.1 hop.

- `rails-upgrade/version-guides/upgrade-4.2-to-5.0.md` → new #10 entry under 🟡 MEDIUM with What Changed / detection / BEFORE-AFTER and a forward note pointing at the 5.1 removal.
- `rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml` → matching MEDIUM pattern `REDIRECT_TO_BACK_DEPRECATED` scoped to `app/controllers/`.

### Convention applied across both hops

- Deprecation-introduction hop → 🟡 MEDIUM, framing: "deprecated — fix now before the next hop."
- Removal hop → 🔴 HIGH, framing: "removed — raises at runtime."

---

## Acceptance criteria (issue #14)

- [x] Create `rails-51-patterns.yml` covering all breaking changes from the version guide
- [x] Organize patterns into `high_priority` and `medium_priority` sections
- [x] Include `dependencies:` section for any bridge/compatibility gems
- [x] Verify YAML parses without errors
- [x] Verify naming convention matches `rails-{VERSION}-patterns.yml` for auto-discovery by `direct-detection-workflow.md`

## Test plan

- [x] `ruby -e "require 'yaml'; YAML.safe_load_file('rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml')"` succeeds
- [x] `ruby -e "require 'yaml'; YAML.safe_load_file('rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml')"` succeeds
- [x] All regexes compile under Ruby's Oniguruma
- [ ] Manual smoke: run the detection on a Rails 5.0 app and confirm the HIGH patterns (`*_filter`, `redirect_to :back`, `render :text`, controller-test positional args) fire where expected
- [ ] Manual smoke: run the detection on a Rails 4.2 app and confirm `REDIRECT_TO_BACK_DEPRECATED` fires on `redirect_to :back` call sites
