### PR TITLE
Fix 5.0 → 5.1 guide: redirect_to :back was removed, not deprecated

### DIFF
--- a/rails-upgrade/version-guides/upgrade-5.0-to-5.1.md
+++ b/rails-upgrade/version-guides/upgrade-5.0-to-5.1.md
@@ -103,12 +103,10 @@ render body: 'raw content', layout: true
 
 ---
 
-### 🟡 MEDIUM PRIORITY
-
-#### 5. redirect_to :back Deprecated
+#### 5. redirect_to :back Removed
 
 **What Changed:**
-`redirect_to :back` is deprecated.
+`redirect_to :back` was deprecated in Rails 5.0 and **removed** in Rails 5.1. Callers raise at runtime.
 
 **Detection Pattern:**
 ```ruby
@@ -126,7 +124,11 @@ redirect_back(fallback_location: root_path)
 redirect_back(fallback_location: root_path, notice: 'Done!')
 ```
 
+`redirect_back` accepts a `fallback_location:` used when `HTTP_REFERER` is missing — without it, requests with no referer raise `ActionController::RedirectBackError`.
+
 ---
+
+### 🟡 MEDIUM PRIORITY
 
 #### 6. Positional Arguments in Process Methods
 
@@ -284,7 +286,7 @@ render plain: 'content'
 
 **Error:** `ActionController::RedirectBackError`
 
-**Cause:** No referer and using deprecated syntax
+**Cause:** `redirect_to :back` was removed in 5.1, and `redirect_back` without a `fallback_location:` still raises when `HTTP_REFERER` is missing
 
 **Fix:**
 ```ruby

--- a/rails-upgrade/version-guides/upgrade-5.0-to-5.1.md
+++ b/rails-upgrade/version-guides/upgrade-5.0-to-5.1.md
@@ -282,13 +282,26 @@ config.load_defaults 5.1
 render plain: 'content'
 ```
 
-### Issue: redirect_to :back Fails
+### Issue: `redirect_to :back` raises after the upgrade
 
-**Error:** `ActionController::RedirectBackError`
+**Cause:** `redirect_to :back` was deprecated in Rails 5.0 and **removed** in Rails 5.1. Callers raise at runtime.
 
-**Cause:** `redirect_to :back` was removed in 5.1, and `redirect_back` without a `fallback_location:` still raises when `HTTP_REFERER` is missing
+**Fix:** Replace every call site with `redirect_back(fallback_location: ...)`:
+```ruby
+# BEFORE (5.0 — raises on 5.1)
+redirect_to :back
 
-**Fix:**
+# AFTER
+redirect_back(fallback_location: root_path)
+```
+
+### Issue: `redirect_back` itself raises on a request with no referer
+
+**Error:** `ActionController::RedirectBackError` (or `ActionController::ActionControllerError` on newer versions)
+
+**Cause:** `redirect_back` still needs a fallback when `HTTP_REFERER` is missing (direct navigation, bookmarked POSTs, some crawlers).
+
+**Fix:** Always pass `fallback_location:`:
 ```ruby
 redirect_back(fallback_location: root_path)
 ```


### PR DESCRIPTION
> **Consolidation note (2026-04-22):** this PR will be folded into #38 rather than merged standalone. #38 is the authoritative draft for all 5.0 → 5.1 coverage (patterns YAML + this guide fix). Once #38 picks up these commits, close this PR without merging. A separate follow-up PR will add the `redirect_to :back` *deprecation* entry to the `upgrade-4.2-to-5.0.md` guide + `rails-50-patterns.yml` (the hop where the deprecation actually starts).

---

## Summary

`rails-upgrade/version-guides/upgrade-5.0-to-5.1.md` listed `redirect_to :back` under 🟡 MEDIUM priority and described it as "deprecated". It was deprecated in Rails 5.0 but **removed** in Rails 5.1 — callers raise at runtime, not just emit a warning.

Source: official [Removed deprecated support of `redirect_to :back`](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#removed-deprecated-support-of-redirect-to-back).

## Changes

- Moved the entry from 🟡 MEDIUM to 🔴 HIGH.
- Reworded "is deprecated" → "was deprecated in Rails 5.0 and **removed** in Rails 5.1. Callers raise at runtime."
- Added a note about `fallback_location:` being required when `HTTP_REFERER` may be missing.
- Split the matching Common Issues entry into two distinct cases so the Cause lines are accurate:
  1. `redirect_to :back` raising because it was removed in 5.1.
  2. `redirect_back` itself raising `RedirectBackError` when the referer is missing and no `fallback_location:` was given — a separate, ongoing hazard of the new API.

## Context

Surfaced during review of #38 (5.0 → 5.1 detection patterns) — the YAML flags `redirect_to :back` as HIGH; the guide said MEDIUM. The guide was wrong.

## Follow-up (separate PR)

`redirect_to :back` was *deprecated* in 5.0, so the `upgrade-4.2-to-5.0.md` guide and `rails-50-patterns.yml` should also mention it (as 🟡 MEDIUM, "deprecated — fix before the 5.1 hop"). Neither currently does. A separate PR will close that gap. Convention across the repo:
- Deprecation-introduction hop → MEDIUM, framing: "deprecated, fix now."
- Removal hop → HIGH, framing: "removed, raises at runtime."

## Test plan

- [x] `grep -n "redirect_to :back" rails-upgrade/version-guides/upgrade-5.0-to-5.1.md` — still appears in the Breaking Change entry, Fix examples, Migration Steps checklist, and Common Issues as intended.
- [x] No other "deprecated" wording related to `redirect_to :back` remains.
