### PR TITLE
Add redirect_to :back deprecation to 4.2 → 5.0 guide and patterns

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml
@@ -100,6 +100,15 @@ breaking_changes:
       fix: "Replace with Rack::Test::UploadedFile.new(file_path, content_type)"
       variable_name: "UPLOAD_FILE_TEST"
 
+    - name: "redirect_to :back deprecated"
+      pattern: "redirect_to\\s+:back\\b"
+      exclude: ""
+      search_paths:
+        - "app/controllers/"
+      explanation: "Rails 5.0 deprecates redirect_to :back (emits a deprecation warning). It is removed outright in Rails 5.1, so fix all call sites now to avoid a runtime break on the next hop"
+      fix: "Replace with redirect_back(fallback_location: root_path). Pass any flash/notice options as keyword args: redirect_back(fallback_location: root_path, notice: 'Done!')"
+      variable_name: "REDIRECT_TO_BACK_DEPRECATED"
+
     - name: "rake commands in scripts or docs"
       pattern: "\\brake\\s+(db:|test|routes|assets:|secret)"
       exclude: ""

--- a/rails-upgrade/version-guides/upgrade-4.2-to-5.0.md
+++ b/rails-upgrade/version-guides/upgrade-4.2-to-5.0.md
@@ -253,6 +253,31 @@ rails routes
 
 ---
 
+#### 10. `redirect_to :back` Deprecated
+
+**What Changed:**
+`redirect_to :back` is deprecated in Rails 5.0. It still works and emits a deprecation warning, but it is **removed outright in Rails 5.1** — fix all call sites now to avoid a runtime break on the next hop.
+
+**Detection Pattern:**
+```ruby
+redirect_to :back
+redirect_to :back, notice: 'Done!'
+```
+
+**Fix:**
+```ruby
+# BEFORE
+redirect_to :back
+
+# AFTER
+redirect_back(fallback_location: root_path)
+redirect_back(fallback_location: root_path, notice: 'Done!')
+```
+
+`redirect_back` accepts a `fallback_location:` used when `HTTP_REFERER` is missing — without it, requests with no referer raise `ActionController::RedirectBackError`.
+
+---
+
 ## Gem Compatibility
 
 Check gems at [RailsBump](https://railsbump.org/) before upgrading.


### PR DESCRIPTION
> **Draft — stacked on top of #38.** Base is `feature/rails-5-0-to-5-1-patterns`. Review / merge #38 first; this branch will be rebased onto main once #38 lands.

## Summary

`redirect_to :back` was deprecated in Rails 5.0 and removed in Rails 5.1. The removal side is covered in #38 (5.0 → 5.1 materials, 🔴 HIGH). The deprecation side was missing from the 4.2 → 5.0 materials — a blind spot where a user upgrades to 5.0, never sees the call-site flagged by the skill, then hits runtime errors on the 5.1 hop.

## Related PRs

- **#38** (base of this PR) — adds `redirect_to :back` as 🔴 HIGH to the 5.0 → 5.1 guide and detection patterns. Folds in the guide-side fix originally opened as **#39** (now merged into #38's branch).
- **#39** (merged into #38) — original fix that reworded the 5.0 → 5.1 guide entry from "deprecated" to "removed" and split the Common Issues section. Context for why the deprecation/removal split matters.

## Repo convention applied

- Deprecation-introduction hop → 🟡 **MEDIUM**, framing: "deprecated — fix now before the next hop."
- Removal hop → 🔴 **HIGH**, framing: "removed — raises at runtime."

## Changes

- `rails-upgrade/version-guides/upgrade-4.2-to-5.0.md` → new §10 `redirect_to :back Deprecated` under MEDIUM with What Changed / detection / BEFORE-AFTER and a forward note pointing at the 5.1 removal.
- `rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml` → matching MEDIUM pattern `REDIRECT_TO_BACK_DEPRECATED` scoped to `app/controllers/`.

## Sources

- Official [Upgrading from Rails 4.2 to Rails 5.0](https://guides.rubyonrails.org/v5.0/upgrading_ruby_on_rails.html) (5.0 release notes listed `redirect_to :back` under deprecations)
- OmbuLabs ebook chapter `from-4-2-to-5-0.md`

## Test plan

- [x] `ruby -e "require 'yaml'; YAML.safe_load_file('rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml')"` succeeds
- [x] Pattern regex compiles
- [ ] Manual smoke: run the detection on a Rails 4.2 app containing `redirect_to :back` and confirm the new pattern fires once
