### PR TITLE
Add CI config check before opening the upgrade PR (closes #41)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rails-upgrade",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Plan and execute Rails version upgrades following FastRuby.io methodology",
   "skills": "./rails-upgrade/",
   "author": {

--- a/rails-upgrade/CHANGELOG.md
+++ b/rails-upgrade/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2 — April 2026
+- Added a **CI config check** at the end of Step 5, before opening the upgrade PR. New workflow file: `workflows/ci-sync-workflow.md`. Claude now lists every CI file in the repo, compares Ruby / Rails / service versions against the upgraded Gemfile, and stops to fix any mismatches. Addresses a real incident where a 7.1 → 7.2 upgrade PR opened with stale CI config. (Closes #41)
+- Wired the check into SKILL.md Core Workflow Step 5, High-Level Workflow, Pattern 1, Quality Checklist, Key Principles, and Success Criteria so it is enforced, not just mentioned.
+
 ## v3.1 — March 2026
 - Added mandatory Step 0: Verify Latest Patch Version — ensures app is on latest patch of current series before any minor/major hop
 - Added latest patch versions reference table in `reference/multi-hop-strategy.md`

--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -105,6 +105,7 @@ When proposing code fixes that must work with both the current and target Rails 
 - Update Gemfile to target Rails version
 - Run test suite against both versions during the transition
 - Do not fix deprecations printed by the next version, these will be addressed later before the next upgrade
+- **Check CI config before opening the PR (MANDATORY):** follow `workflows/ci-sync-workflow.md` to verify every CI file in the repo matches the upgraded Gemfile (Ruby version, Rails matrix, service versions). Fix any mismatches before Step 5 is complete. Stale CI config is the most common cause of red builds on upgrade PRs.
 - Deploy and verify
 
 ### Step 6: Align load_defaults to New Version (FINAL STEP)
@@ -220,6 +221,7 @@ If user requests a multi-hop upgrade (e.g., 5.2 → 8.1):
 - `workflows/test-suite-verification-workflow.md` - **MANDATORY FIRST STEP** - How to run and verify test suite
 - `workflows/direct-detection-workflow.md` - How to run breaking change detection directly
 - `workflows/upgrade-report-workflow.md` - How to generate upgrade reports
+- `workflows/ci-sync-workflow.md` - **MANDATORY before opening the upgrade PR** - How to verify CI config matches the upgraded Gemfile
 - `workflows/app-update-preview-workflow.md` - How to generate app:update previews
 
 ### Examples (Load when user needs clarification)
@@ -341,7 +343,8 @@ Claude runs detection directly using tools - NO script generation needed
 3. Implement breaking change fixes using `NextRails.next?` for dual-boot code
 4. Update Gemfile to target Rails version
 5. Run test suite against both versions
-6. Deploy and verify
+6. **Check CI config matches the upgraded Gemfile** — load `workflows/ci-sync-workflow.md`, fix any mismatches before proceeding
+7. Deploy and verify
 ```
 
 ### Step 7: Align load_defaults (FINAL STEP)
@@ -428,7 +431,9 @@ Before starting ANY upgrade:
 **Action - Step 5 (Implement & Upgrade):**
 1. Fix breaking changes using `NextRails.next?` for dual-boot code
 2. Update Gemfile to target Rails version
-3. Run tests against both versions, deploy and verify
+3. Run tests against both versions
+4. **Check CI config matches the upgraded Gemfile** (`workflows/ci-sync-workflow.md`) — fix any mismatches before declaring Step 5 complete
+5. Deploy and verify
 
 **Action - Step 6 (Align load_defaults - FINAL):**
 1. DELEGATE to the `rails-load-defaults` skill
@@ -496,6 +501,12 @@ Before delivering, verify:
 - [ ] Code examples use user's actual code from affected files
 - [ ] Next steps clearly outlined
 
+**For CI Config Check (Step 5, before opening the PR):**
+- [ ] Every CI file in the repo enumerated (GitHub Actions, CircleCI, Jenkins, GitLab, etc.)
+- [ ] Ruby version, Rails matrix, and service versions diffed against the upgraded Gemfile
+- [ ] CI sync report produced with per-file verdict
+- [ ] All DRIFT entries fixed; overall verdict is OK
+
 **For app:update Preview:**
 - [ ] All {PLACEHOLDERS} replaced with actual values
 - [ ] File list matches user's actual config files
@@ -519,7 +530,8 @@ Before delivering, verify:
 11. **Sequential Process is Critical** (patch check → tests → dual-boot → detection → reports → implement → load_defaults)
 12. **Follow FastRuby.io Methodology** (incremental upgrades, assessment first)
 13. **Always Use `NextRails.next?` for Dual-Boot Code** (NEVER use `respond_to?` for version branching. DELEGATE to the `dual-boot` skill for patterns and setup.)
-14. **Align load_defaults Last** (load_defaults update happens AFTER the Rails version upgrade is complete, as the final step)
+14. **Check CI Config Before Opening the PR** (run `workflows/ci-sync-workflow.md` to make sure every CI file matches the upgraded Gemfile — stale CI is the most common cause of red builds on upgrade PRs)
+15. **Align load_defaults Last** (load_defaults update happens AFTER the Rails version upgrade is complete, as the final step)
 
 ---
 
@@ -539,6 +551,7 @@ A successful upgrade assistance session:
 ✅ Used user's actual code from findings (not generic examples)
 ✅ Flagged all custom code with ⚠️ warnings based on detected issues
 ✅ **Implemented changes and upgraded Rails version**
+✅ **Verified CI config matches the upgraded Gemfile** (Ruby, Rails matrix, services — all mismatches fixed before opening the PR)
 ✅ **Aligned load_defaults** (final step, after upgrade is complete)
 ✅ Provided clear next steps
 ✅ Offered to help implement changes

--- a/rails-upgrade/workflows/ci-sync-workflow.md
+++ b/rails-upgrade/workflows/ci-sync-workflow.md
@@ -1,0 +1,96 @@
+# CI Sync Workflow
+
+**When to load:** Step 5, immediately before declaring the upgrade complete or opening a PR. Also any time the user reports a red CI build after an upgrade PR is opened.
+
+**Purpose:** Verify every CI configuration file in the repo matches the versions declared in the upgraded `Gemfile` / `Gemfile.lock`. CI drift (old Ruby version, old Rails matrix, stale service versions) is a frequent cause of red builds on the upgrade PR and is easy to miss because the local test suite passes.
+
+This workflow is **mandatory**, not a reminder — produce a written CI sync report and do not open the PR until every CI file matches the Gemfile.
+
+---
+
+## Step 1: Enumerate CI files
+
+Use Glob to find every CI configuration file in the repo. Check all of these locations — projects commonly have more than one:
+
+- `.github/workflows/*.yml` and `.github/workflows/*.yaml` (GitHub Actions)
+- `.circleci/config.yml` (CircleCI)
+- `Jenkinsfile`, `Jenkinsfile.*`, `.jenkins/*` (Jenkins)
+- `.gitlab-ci.yml` (GitLab CI)
+- `appveyor.yml`, `.appveyor.yml` (AppVeyor)
+- `.travis.yml` (Travis CI — rare today but still present on legacy apps)
+- `azure-pipelines.yml` (Azure Pipelines)
+- `bitbucket-pipelines.yml` (Bitbucket Pipelines)
+- `buildkite/*.yml`, `.buildkite/*.yml` (Buildkite)
+
+If none are found:
+
+- The app may rely on an external CI system (Heroku CI, Render, etc.) that this skill cannot inspect — flag this to the user and stop; the user has to verify CI themselves.
+- The app may have no CI at all. Do **not** create one from scratch as part of the upgrade — the shape of a CI setup depends on the team's deploy pipeline and is out of scope here. Note it in the report (`No CI files found — skipping CI sync`) and continue with the rest of Step 5; do not block the upgrade on it. Adding CI is a separate decision the team should make outside the upgrade flow.
+
+## Step 2: Read the Gemfile baseline
+
+**First, identify the upgrade scope:** is this a Rails upgrade or a Ruby upgrade? Check what changed in the Gemfile / `Gemfile.next` compared to current `Gemfile.lock`. Only sync the dimension that actually changed — a Rails upgrade leaves the Ruby matrix alone; a Ruby upgrade leaves the Rails matrix alone. Touching the unchanged dimension adds noise and risks breaking a currently-green CI job.
+
+Then record the versions CI should match. Only read the ones relevant to this upgrade (Ruby for a Ruby upgrade, Rails for a Rails upgrade):
+
+- **Ruby version** — precedence: `Gemfile`'s `ruby "..."` line → current CI's Ruby → `.ruby-version`. The Gemfile is preferred because a `NextRails.next?` conditional makes both current and next Ruby explicit for the matrix.
+- **Rails version constraint** — from `Gemfile` (`gem "rails", "~> X.Y.Z"`) and the resolved version in `Gemfile.lock`.
+- **Next-Rails version** — if dual-boot is active, from `Gemfile.next.lock`.
+- **Service versions** — default is to **replicate whatever the current CI already runs** (Postgres, Redis, MySQL, Elasticsearch, etc.). If CI is green today, those versions work. Only propose a bump when the upgrade explicitly requires it (e.g. the version guide or a bumped gem's changelog calls out a minimum). When in doubt, keep current CI service versions and note them in the report as `unchanged — matches current CI`.
+- **Node / Yarn / bun version** — default to whatever the current CI uses. Only flag for change if the app's `package.json` engines, `.nvmrc`, or `.tool-versions` disagree with CI, or if the upgrade explicitly bumps the Node requirement.
+
+## Step 3: Diff each CI file against the baseline
+
+For each CI file, read it and check:
+
+1. **Ruby version(s)** in the CI matrix, setup-ruby action, container image tag, or `rvm:` / `ruby:` key match the Gemfile baseline. For dual-boot, confirm both current Ruby AND (if applicable) next Ruby are present.
+2. **Rails / BUNDLE_GEMFILE matrix** includes both `Gemfile` and `Gemfile.next` during dual-boot. After dual-boot cleanup, only `Gemfile`.
+   - **If dual-boot is active but CI has no `Gemfile.next` matrix entry at all** (common when CI was set up before the upgrade started): this is a `DRIFT` finding. Extend the existing job matrix with a `BUNDLE_GEMFILE=Gemfile.next` entry (or duplicate the job and add the env var) so both versions run on every PR. Do NOT silently add it — show the user the proposed matrix diff and confirm before editing. Refer to the dual-boot skill's CI reference for platform-specific matrix patterns (GitHub Actions, CircleCI, etc.).
+   - **If the CI file has no matrix concept at all** (single-job Jenkinsfile, simple Bitbucket pipeline): flag as `DRIFT — needs dual-boot wiring` and surface to the user rather than attempting an automatic rewrite; the shape of the fix depends on the pipeline.
+3. **Service containers / images** (Postgres, Redis, MySQL, etc.) — default to leaving current CI service versions as-is. Only flag `DRIFT` if the upgrade explicitly requires a bump (called out in the version guide or a bumped gem's changelog). If a dual-boot job is being added, copy the services block from the current job rather than inventing new versions.
+4. **Node / Yarn / bun** — keep the current CI value unless `package.json` engines / `.nvmrc` / `.tool-versions` disagree with it, or the upgrade explicitly bumps the Node requirement.
+5. **Bundler version** pinned in CI (`bundler-cache: true` or `bundle install` step) is not older than `Gemfile.lock`'s `BUNDLED WITH`.
+6. **Cache keys** that include Ruby or Rails version in the key string are updated, otherwise the cache will hit stale data and miss the new dependencies.
+7. **Deprecated action versions** (e.g. `actions/checkout@v2`, `ruby/setup-ruby@v1` with an old Ruby) — optional to flag.
+
+## Step 4: Produce the CI sync report
+
+Emit a concise report. Only include CI files that were actually found in the repo — skip absent ones. One block per found file, plus a top-level verdict:
+
+```
+CI Sync Report
+--------------
+Gemfile baseline: Ruby 3.3.6, Rails 7.2.2, Node 20
+
+.github/workflows/ci.yml
+  Ruby matrix: [3.1, 3.2] ✗ (expected 3.3.6)
+  Rails matrix: [Gemfile] (dual-boot removed — OK)
+  Postgres service: 13 (unchanged — matches current CI)
+  Verdict: DRIFT — fix before PR
+
+Overall: 1 file needs changes. BLOCKING.
+```
+
+If the verdict is `DRIFT` for any file, do not mark Step 5 complete. Apply the edits, re-run the diff, and only proceed when the overall verdict is `OK`.
+
+## Step 5: Apply fixes
+
+Edit each drifting CI file directly. Prefer:
+
+- **Reuse the existing matrix shape.** If a matrix is already defined (Ruby versions, Gemfile variants, service combinations), keep its structure and just update the values. Do not invent a new matrix layout when one exists.
+- Bump matrix entries in place rather than adding new ones, unless the user explicitly wants to keep the old version running alongside.
+- Only change service image tags when the upgrade explicitly requires it; otherwise preserve what the current CI runs.
+- Remove `Gemfile.next` matrix entries only after the dual-boot cleanup step has run (coordinate with the dual-boot skill's cleanup contract).
+
+After fixes, re-run Step 3 and regenerate the report. The report is part of the upgrade PR description when possible — it gives reviewers a clear audit trail.
+
+---
+
+## Common failure modes this workflow catches
+
+- CI still running on the old Ruby patch after `.ruby-version` was bumped.
+- Postgres / MySQL service container on a version the new Rails release dropped support for.
+- Dual-boot removed locally but CI matrix still has `BUNDLE_GEMFILE=Gemfile.next` entries (builds fail because `Gemfile.next` no longer exists).
+- Dual-boot set up locally but CI was never extended — the matrix still runs only the current `Gemfile`, so the next-Rails build never runs on PRs and breakages land unnoticed.
+- GitHub Actions cache key pinned to old Rails version, causing phantom "works locally, fails in CI" bundle resolution mismatches.
+- Node engine bumped in `package.json` but CI still using an older Node major — asset compilation fails.


### PR DESCRIPTION
## Summary

Closes #41.

Adds `workflows/ci-sync-workflow.md` and wires it into Step 5 of the Core Workflow. Before opening the upgrade PR, Claude now enumerates every CI file in the repo, compares the in-scope dimension (Ruby for a Ruby upgrade, Rails for a Rails upgrade) against the upgraded Gemfile, and stops to fix any mismatches.

Motivated by a real incident: a 7.1 → 7.2 upgrade opened a PR with stale CI config because nothing in the workflow reminded the agent to sync CI after bumping the Gemfile.

## Design choices

- **Single-axis scope.** A Rails upgrade leaves Ruby alone; a Ruby upgrade leaves Rails alone. Touching the unchanged dimension risks breaking a currently-green CI job.
- **Gemfile is the primary Ruby baseline.** A `NextRails.next?` conditional around `ruby "..."` encodes both current and next Ruby explicitly, which `.ruby-version` cannot. Fallback order: `Gemfile` → existing CI → `.ruby-version`.
- **Services default to replicating current CI.** Postgres, Redis, MySQL, Node, etc. — if CI is green today those versions work. Only bump when the version guide or a bumped gem's changelog explicitly calls for it.
- **Reuse the existing matrix shape.** Bump entries in place rather than redesigning. Adding a `BUNDLE_GEMFILE=Gemfile.next` entry to a dual-boot job requires user confirmation (never silent).
- **No CI at all** → note in report and continue; do not block the upgrade, do not bootstrap CI (out of scope).
- **External CI** (Heroku CI, Render, etc.) → flag and stop; this skill can't inspect it.
- **Report only lists CI files that exist.** Absent files are skipped, not listed as "not present".

## Wiring

The check is referenced from every place Claude looks during an upgrade:

- `SKILL.md` Core Workflow Step 5 (MANDATORY bullet)
- `SKILL.md` High-Level Workflow (Step 5 step 6)
- `SKILL.md` Pattern 1 (Action — Step 5)
- `SKILL.md` Available Resources (Workflow Guides)
- `SKILL.md` Quality Checklist (new "CI Config Check" block)
- `SKILL.md` Key Principles (#14)
- `SKILL.md` Success Criteria
## Test plan

- [ ] Manual: run the skill on a Rails app mid-upgrade with a deliberately stale `.github/workflows/ci.yml` (old Ruby matrix, missing `Gemfile.next` entry) and confirm the CI sync report flags both findings before the PR stage.
- [ ] Manual: run on an app with no CI files and confirm the skill notes it and continues without blocking.
- [ ] Manual: run on an app whose CI uses CircleCI (not GH Actions) and confirm the enumeration step picks it up.