### PR TITLE
Add bin/validate-patterns for pattern YAML validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This file captures project-specific conventions Claude should follow when workin
 - Organize patterns under `high_priority`, `medium_priority`, and `low_priority`.
 - Each pattern needs: `name`, `pattern` (regex), `exclude` (regex, empty string if none), `search_paths`, `explanation`, `fix`, `variable_name`.
 - Include a `dependencies` section for any bridge/compatibility gems mentioned in the guide.
-- Verify the file before committing with `bin/validate-patterns` (validates every pattern file) or `bin/validate-patterns path/to/file.yml` (single file). The script checks YAML parses, the seven required pattern keys are present, and each `pattern` / `exclude` regex compiles.
+- **Required before committing any change to a detection pattern file:** run `bin/validate-patterns` (or `bin/validate-patterns path/to/file.yml` for the file you touched). Do not commit a pattern change without a clean run; broken YAML or schema drift in this directory breaks the skill at runtime. See the `## Repository tooling` section above for what the script checks.
 
 ## Assigning priority (🔴 HIGH / 🟡 MEDIUM / 🟢 LOW)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file captures project-specific conventions Claude should follow when working in this repo.
 
+## Repository tooling
+
+- `bin/validate-patterns` validates every detection pattern YAML file under `rails-upgrade/detection-scripts/patterns/`. Run it before committing any change to a pattern file. Pure-stdlib Ruby, no Bundler or Gemfile required.
+  - `bin/validate-patterns` validates every file
+  - `bin/validate-patterns path/to/file.yml` validates one or more specific files
+  - Checks: YAML parses, required top-level keys present, the seven required pattern keys present on each entry, and every `pattern` / `exclude` regex compiles
+  - Exits 0 on success, 1 on any failure with a per-file error report
+
 ## Version guides (`rails-upgrade/version-guides/*.md`)
 
 - **Do NOT include "Difficulty" or "Estimated Time" in the header.** These are subjective, application-dependent, and drift out of date. Keep the header minimal: title, Ruby requirement, and the attribution line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file captures project-specific conventions Claude should follow when workin
 - Organize patterns under `high_priority`, `medium_priority`, and `low_priority`.
 - Each pattern needs: `name`, `pattern` (regex), `exclude` (regex, empty string if none), `search_paths`, `explanation`, `fix`, `variable_name`.
 - Include a `dependencies` section for any bridge/compatibility gems mentioned in the guide.
-- Verify YAML parses before committing (`ruby -e "require 'yaml'; YAML.safe_load(File.read('...'))"`).
+- Verify the file before committing with `bin/validate-patterns` (validates every pattern file) or `bin/validate-patterns path/to/file.yml` (single file). The script checks YAML parses, the seven required pattern keys are present, and each `pattern` / `exclude` regex compiles.
 
 ## Assigning priority (🔴 HIGH / 🟡 MEDIUM / 🟢 LOW)
 

--- a/bin/validate-patterns
+++ b/bin/validate-patterns
@@ -1,0 +1,94 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Validates Rails upgrade detection-pattern YAML files.
+#
+# Usage:
+#   bin/validate-patterns                # validate every patterns file
+#   bin/validate-patterns path/to/file   # validate a specific file (one or more)
+#
+# Exits 0 if all files pass, 1 otherwise.
+
+require "yaml"
+
+PATTERNS_DIR = File.expand_path("../rails-upgrade/detection-scripts/patterns", __dir__)
+TOP_LEVEL_KEYS = %w[version description breaking_changes].freeze
+PATTERN_KEYS = %w[name pattern exclude search_paths explanation fix variable_name].freeze
+PRIORITY_KEYS = %w[high_priority medium_priority low_priority].freeze
+
+def validate(path)
+  errors = []
+  doc =
+    begin
+      YAML.safe_load_file(path)
+    rescue Psych::SyntaxError => e
+      return ["YAML parse error: #{e.message}"]
+    end
+
+  return ["top level is not a Hash"] unless doc.is_a?(Hash)
+
+  TOP_LEVEL_KEYS.each do |k|
+    errors << "missing top-level key: #{k}" unless doc.key?(k)
+  end
+
+  bc = doc["breaking_changes"]
+  return errors unless bc.is_a?(Hash)
+
+  bc.each do |priority, patterns|
+    next unless PRIORITY_KEYS.include?(priority)
+    next unless patterns.is_a?(Array)
+
+    patterns.each_with_index do |entry, i|
+      label = "#{priority}[#{i}]" + (entry.is_a?(Hash) && entry["name"] ? " (#{entry["name"]})" : "")
+
+      unless entry.is_a?(Hash)
+        errors << "#{label}: not a Hash"
+        next
+      end
+
+      PATTERN_KEYS.each do |k|
+        errors << "#{label}: missing key: #{k}" unless entry.key?(k)
+      end
+
+      %w[pattern exclude].each do |key|
+        val = entry[key]
+        next if key == "exclude" && (val.nil? || val.to_s.empty?)
+        next if val.nil?
+
+        begin
+          Regexp.new(val)
+        rescue RegexpError => e
+          errors << "#{label}: #{key} regex does not compile: #{e.message}"
+        end
+      end
+    end
+  end
+
+  errors
+end
+
+paths =
+  if ARGV.empty?
+    Dir.glob(File.join(PATTERNS_DIR, "*.yml")).sort
+  else
+    ARGV
+  end
+
+if paths.empty?
+  warn "No YAML files to validate"
+  exit 1
+end
+
+failed = false
+paths.each do |path|
+  errors = validate(path)
+  if errors.empty?
+    puts "OK   #{path}"
+  else
+    failed = true
+    puts "FAIL #{path}"
+    errors.each { |e| puts "     - #{e}" }
+  end
+end
+
+exit(failed ? 1 : 0)

--- a/rails-upgrade/CHANGELOG.md
+++ b/rails-upgrade/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.1 — 25 April 2026
+- Added `bin/validate-patterns`: a small Ruby script (stdlib only) that validates every detection pattern YAML file under `rails-upgrade/detection-scripts/patterns/`. Checks that YAML parses, the top-level keys (`version`, `description`, `breaking_changes`) are present, every pattern entry has the seven required keys (`name`, `pattern`, `exclude`, `search_paths`, `explanation`, `fix`, `variable_name`), and each `pattern` / `exclude` regex compiles under Ruby Onigmo.
+- Updated `CLAUDE.md` to point contributors at the script instead of the previous inline-Ruby YAML check.
+
 ## v3.2 — April 2026
 - Added a **CI config check** at the end of Step 5, before opening the upgrade PR. New workflow file: `workflows/ci-sync-workflow.md`. Claude now lists every CI file in the repo, compares Ruby / Rails / service versions against the upgraded Gemfile, and stops to fix any mismatches. Addresses a real incident where a 7.1 → 7.2 upgrade PR opened with stale CI config. (Closes #41)
 - Wired the check into SKILL.md Core Workflow Step 5, High-Level Workflow, Pattern 1, Quality Checklist, Key Principles, and Success Criteria so it is enforced, not just mentioned.


### PR DESCRIPTION
## Summary

Adds a small Ruby script at `bin/validate-patterns` that contributors (and CI, in a follow-up PR) can run to verify pattern YAML files before committing. Replaces the current inline-Ruby instruction in `CLAUDE.md`.

```
- Verify YAML parses before committing (`ruby -e "require 'yaml'; YAML.safe_load(File.read('...'))"`).
```

becomes:

```
- Verify the file before committing with `bin/validate-patterns` (validates every pattern file) or `bin/validate-patterns path/to/file.yml` (single file). The script checks YAML parses, the seven required pattern keys are present, and each `pattern` / `exclude` regex compiles.
```

## What it checks

Per CLAUDE.md's pattern conventions:

- YAML parses
- Top-level keys present: `version`, `description`, `breaking_changes`
- Each pattern entry has the seven required keys: `name`, `pattern`, `exclude`, `search_paths`, `explanation`, `fix`, `variable_name`
- Each `pattern` and non-empty `exclude` regex compiles under Ruby Onigmo

Kept simple per direction. No deep schema checks on `dependencies` entries, no semantic linting of regex quality, no markdown / JSON validation.

## Usage

```bash
bin/validate-patterns                              # validate every pattern file
bin/validate-patterns path/to/file.yml             # validate one file
bin/validate-patterns path/to/a.yml path/to/b.yml  # multiple
```

Exit code is 0 on success, 1 on any failure. Failures print a per-file error list.

## Implementation notes

- Pure Ruby stdlib (`yaml` + `Regexp`). No Bundler, no Gemfile, no extra dependencies.
- Executable bit set; uses `#!/usr/bin/env ruby` shebang.
- Defaults to globbing `rails-upgrade/detection-scripts/patterns/*.yml` when called without arguments.

## Follow-up

A separate PR will add a GitHub Actions workflow that runs `bin/validate-patterns` on push and pull request, so broken YAML or schema drift is caught before merge.

## Test plan

- [x] `bin/validate-patterns` (no args) passes against all 9 existing pattern files on main
- [x] Script catches missing top-level keys, missing pattern keys, and invalid regexes (verified locally with a deliberately broken file)
- [x] Exit code is 1 on failure, 0 on success