### PR TITLE
Run bin/validate-patterns in CI on every push and PR

### DIFF
--- a/.github/workflows/validate-patterns.yml
+++ b/.github/workflows/validate-patterns.yml
@@ -4,14 +4,17 @@ on:
   push:
     branches: [main]
     paths:
-      - "rails-upgrade/detection-scripts/patterns/**"
+      - "rails-upgrade/detection-scripts/patterns/*.yml"
       - "bin/validate-patterns"
       - ".github/workflows/validate-patterns.yml"
   pull_request:
     paths:
-      - "rails-upgrade/detection-scripts/patterns/**"
+      - "rails-upgrade/detection-scripts/patterns/*.yml"
       - "bin/validate-patterns"
       - ".github/workflows/validate-patterns.yml"
+
+permissions:
+  contents: read
 
 jobs:
   validate:

--- a/.github/workflows/validate-patterns.yml
+++ b/.github/workflows/validate-patterns.yml
@@ -3,7 +3,15 @@ name: Validate detection patterns
 on:
   push:
     branches: [main]
+    paths:
+      - "rails-upgrade/detection-scripts/patterns/**"
+      - "bin/validate-patterns"
+      - ".github/workflows/validate-patterns.yml"
   pull_request:
+    paths:
+      - "rails-upgrade/detection-scripts/patterns/**"
+      - "bin/validate-patterns"
+      - ".github/workflows/validate-patterns.yml"
 
 jobs:
   validate:

--- a/.github/workflows/validate-patterns.yml
+++ b/.github/workflows/validate-patterns.yml
@@ -1,0 +1,16 @@
+name: Validate detection patterns
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - run: ruby bin/validate-patterns


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow at `.github/workflows/validate-patterns.yml` that runs `bin/validate-patterns` whenever a push or pull request touches a file relevant to pattern validation. Any change that breaks YAML parse, the seven-key pattern schema, or regex compilation will fail the build before merge.

## Depends on

This PR depends on #44 and is stacked on top of it. Base branch is `feature/validate-patterns-script` (not `main`), so the diff against `main` will only show the workflow file once #44 merges. Until then, GitHub will show this PR's diff against `feature/validate-patterns-script`.

**Merge order: #44 first, then this PR.** After #44 merges to `main`, GitHub will automatically retarget this PR's base to `main`. If for some reason it doesn't, retarget manually before merging.

## Workflow

```yaml
on:
  push:
    branches: [main]
    paths:
      - "rails-upgrade/detection-scripts/patterns/**"
      - "bin/validate-patterns"
      - ".github/workflows/validate-patterns.yml"
  pull_request:
    paths:
      - "rails-upgrade/detection-scripts/patterns/**"
      - "bin/validate-patterns"
      - ".github/workflows/validate-patterns.yml"

jobs:
  validate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: ruby/setup-ruby@v1
        with:
          ruby-version: "3.3"
      - run: ruby bin/validate-patterns
```

### Decisions

- **Paths filter on three locations.** The job runs only when the change affects pattern validation: a pattern YAML file, the validator script itself (since a validator change can break what the YAML must conform to), or the workflow definition. README-only and version-guide-only PRs won't trigger a CI run.
- **Ruby 3.3 pinned.** Stable, widely available, and the script uses only stdlib so the version choice is not load-bearing.
- **No Bundler step.** No Gemfile, no gems. `ruby bin/validate-patterns` is enough.
- **`pull_request` (no qualifier).** Default triggers (`opened`, `synchronize`, `reopened`) are exactly the events we want.

## After merge

If you want this enforced as a required status check in `main`'s branch protection, note that paths-filtered workflows interact with required checks: GitHub's modern rulesets handle skipped runs as passing, but legacy branch-protection rules may report missing checks for filtered-out runs. Verify behavior with a non-pattern PR after enabling the requirement.

## Test plan

- [ ] After #44 merges to `main`, the rebased version of this PR triggers a successful CI run on `main`'s pattern set
- [ ] A PR that only edits a non-pattern file (e.g. README) does NOT trigger the workflow
- [ ] A PR introducing a deliberately broken pattern file fails the workflow with a clear error message
