### PR TITLE
Address review findings on #49 (gem compatibility)

### DIFF
--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -409,6 +409,12 @@ Before starting ANY upgrade:
 3. Use Grep/Glob/Read tools to search for each pattern
 4. Collect findings with file:line references
 
+**Action - Step 4.5 (Check Gem Compatibility):**
+1. Load: `workflows/gem-compatibility-workflow.md` and follow it
+2. Run primary check (`bundle_report compatibility`); escalate to railsbump only when the workflow's conditions trigger
+3. Pass the resulting buckets (required bumps, blockers, already compatible) into Step 5's report
+4. If blockers exist, load `references/gem-compatibility.md` for the fork/replace/vendor playbook
+
 **Action - Step 5 (Generate Reports):**
 1. Load: `workflows/upgrade-report-workflow.md`
 2. Load: `workflows/app-update-preview-workflow.md`

--- a/rails-upgrade/references/gem-compatibility.md
+++ b/rails-upgrade/references/gem-compatibility.md
@@ -29,7 +29,9 @@ When `bundle_report` lists a gem under "with no new compatible versions" or "wit
 1. **Look for a maintained fork** that adds Rails support — search GitHub for "fork of <gem>" with the target Rails in recent commits.
 2. **Check the gem's open PRs / issues** for in-flight Rails support. If a PR is close to merging, ask the user whether to vendor the branch as a temporary `git:` source.
 3. **Wait for an upstream release** if the gem is actively maintained and the next release is imminent.
-4. **Switch to an alternative** if the gem is abandoned (e.g., `paperclip` → `shrine` / Active Storage; `strong_parameters` is built into Rails ≥ 4 so just remove it).
+4. **Switch to an alternative** when the gem is abandoned, OR when a Rails-removed API has a back-compat gem and you'd rather use it than refactor. Examples:
+   - `paperclip` → `shrine` / Active Storage (paperclip is abandoned).
+   - When moving Rails 3 → 4, `attr_accessible` was removed from core. Two paths: refactor controllers to strong parameters, OR add `protected_attributes` to keep `attr_accessible` working. The shim is a valid choice when the controller surface is large and the upgrade timeline is tight; refactoring later is still possible.
 5. **Fork and patch** as a last resort. Document the fork in the Gemfile and open an upstream PR.
 
 Surface the choice to the user — do not silently swap gems. Each option has a different long-term cost.

--- a/rails-upgrade/workflows/gem-compatibility-workflow.md
+++ b/rails-upgrade/workflows/gem-compatibility-workflow.md
@@ -141,7 +141,7 @@ Top-level `status`: `pending` | `complete` | `failed`. Per-`gem_check` `result`:
 
 Wait `retry_after_seconds` (clamped 30-600 by the server). Then GET `status_url`. Loop until top-level `status` is `complete` or `failed`.
 
-**Cap: 10 polls OR 30 minutes total elapsed, whichever comes first.** Track elapsed time across the polls (the server's `retry_after_seconds` can grow). At the cap, give up — report the slug to the user, note that the secondary check stalled, and proceed with whatever the primary produced.
+**Cap: 10 polls OR 30 minutes total elapsed, whichever comes first.** Track elapsed time across the polls so the 30-minute ceiling kicks in regardless of the per-poll wait. (The server returns a `retry_after_seconds` derived from gem count and worker concurrency — both fixed for a given lockfile — so the value is constant across polls, not growing. The 30-minute cap bounds the *total* check; the 10-poll cap protects against a stuck pending state.) At the cap, give up — report the slug to the user, note that the secondary check stalled, and proceed with whatever the primary produced.
 
 Do not poll faster than the server's `retry_after_seconds`. The check is per-gem CPU work; hammering the endpoint will not return results sooner.
 

--- a/rails-upgrade/workflows/gem-compatibility-workflow.md
+++ b/rails-upgrade/workflows/gem-compatibility-workflow.md
@@ -65,7 +65,7 @@ turbo-sprockets-rails3 0.3.14 - new version not found
 | "with no new versions" | blockers | Vendor / fork / replace — gem is abandoned or pre-extraction |
 | (gem not listed in any section) | already compatible | Note the locked version; no action |
 
-If the command produces no output at all, treat it as `bundle_report` failing — escalate to the secondary check.
+If the command produces no output at all, or if the output contains no `=> incompatible with rails X` headers despite an exit code of 0, treat it as `bundle_report` failing or producing an unparseable result — escalate to the secondary check rather than assuming "all gems compatible." A future `next_rails` release that reformats the output would otherwise silently produce empty buckets.
 
 ---
 
@@ -188,3 +188,4 @@ When the agent later runs the actual `bundle update`, prefer one gem at a time (
 - **Slugs expire.** Don't store railsbump slugs across sessions. Re-POST the lockfile if the user comes back later.
 - **Compatibility ≠ green tests.** A `compatible` result means "the gem's gemspec accepts the target Rails" (and for railsbump, "the lockfile resolves"). Tests are still the ground truth.
 - **Submit each lockfile once per session.** Cache the slug in conversation context.
+- **Re-POST when the lockfile changes.** Any time the agent runs `bundle install`, `bundle update`, or otherwise modifies `Gemfile.lock` mid-session, discard the cached slug and POST again. The prior result was for a different lockfile and will mislead the gem-update plan.

--- a/rails-upgrade/workflows/gem-compatibility-workflow.md
+++ b/rails-upgrade/workflows/gem-compatibility-workflow.md
@@ -154,7 +154,7 @@ The API may return multiple `lockfile_checks` (one per Rails release it tested a
 | `result: "incompatible"`, `earliest_compatible_version` set | required bumps | Bump to at least `earliest_compatible_version` |
 | `result: "incompatible"`, `earliest_compatible_version` null | blockers | No compatible version exists — fork / vendor / replace |
 | `result: "compatible"` | already compatible | Note the locked version |
-| `result: "unknown"` or non-empty `error_message` | unresolved | Surface the error; ask the user how to proceed |
+| `result: "unknown"` or non-empty `error_message` | blockers (pending information) | Surface the error to the user. If `bundle_report` was also run and answered this gem, prefer its verdict (see Reconciliation). If railsbump is the only signal, treat as a blocker until the user can verify manually — do not silently assume compatible. |
 
 ---
 
@@ -174,7 +174,7 @@ When the orchestrator triggered the secondary because of an ambiguous primary re
 
 Whichever check ran, the output handed to Step 5 is the same three buckets:
 
-1. **Blockers** — incompatible gems with no compatible version. The hop cannot complete until each one is resolved (see `references/gem-compatibility.md` for the playbook).
+1. **Blockers** — incompatible gems with no compatible version, plus any gems where railsbump returned `unknown`/errored and `bundle_report` did not give a clean answer. The hop cannot complete until each one is resolved (see `references/gem-compatibility.md` for the playbook). Mark "pending information" blockers separately so the user knows they may turn into "compatible" or "required bumps" once the missing data lands.
 2. **Required bumps** — incompatible gems with a target version. Order top-level gems before their internal dependencies, so bundler can resolve the graph from the root. Example: bump `rspec-rails` before `rspec-mocks` — `rspec-rails` is the gem your Gemfile names directly, and it pulls `rspec-mocks` (and the rest of the rspec-* family) transitively.
 3. **Already compatible** — no action needed, but note the locked version so the user can see headroom.
 

--- a/rails-upgrade/workflows/gem-compatibility-workflow.md
+++ b/rails-upgrade/workflows/gem-compatibility-workflow.md
@@ -175,7 +175,7 @@ When the orchestrator triggered the secondary because of an ambiguous primary re
 Whichever check ran, the output handed to Step 5 is the same three buckets:
 
 1. **Blockers** — incompatible gems with no compatible version. The hop cannot complete until each one is resolved (see `references/gem-compatibility.md` for the playbook).
-2. **Required bumps** — incompatible gems with a target version. Order by dependency depth where obvious (e.g., bump `rspec-rails` before `rspec-mocks`).
+2. **Required bumps** — incompatible gems with a target version. Order top-level gems before their internal dependencies, so bundler can resolve the graph from the root. Example: bump `rspec-rails` before `rspec-mocks` — `rspec-rails` is the gem your Gemfile names directly, and it pulls `rspec-mocks` (and the rest of the rspec-* family) transitively.
 3. **Already compatible** — no action needed, but note the locked version so the user can see headroom.
 
 When the agent later runs the actual `bundle update`, prefer one gem at a time (`bundle update <gem> --conservative`) so a single bad resolution does not poison the whole graph.


### PR DESCRIPTION
Follow-up to #49 (railsbump compatibility) and #51 (SKILL.md consolidation).

## Summary

Six small fixes surfaced by a post-merge code review of #49. All scoped to the gem-compatibility flow — no behavioral change to other parts of the skill.

## Commits

1. **`f3132eb` Clarify dependency-ordering rationale in hand-off** — the workflow said "Order by dependency depth where obvious (e.g., bump `rspec-rails` before `rspec-mocks`)." "Dependency depth" was ambiguous (deeper-first vs shallower-first). Reworded to "top-level first, so bundler can resolve from the root" with the rspec-rails relationship spelled out.

2. **`fbabacd` Define hand-off disposition for railsbump's "unresolved" gems** — the hand-off claimed three buckets (Blockers, Required bumps, Already compatible) but railsbump's bucket-mapping table defined a fourth ("unresolved" for `unknown` / errored). When railsbump was the sole source those gems were orphaned. Folded into Blockers as "pending information" so the user sees them as actionable rather than silently assumed compatible.

3. **`8115183` Replace muddled "switch to an alternative" example** — the playbook's item 4 ("Switch to an alternative") had two examples: paperclip → shrine (correct fit), and "strong_parameters is built into Rails ≥ 4 so just remove it" (wrong fit — that's a "false-blocker" / "merged into core" pattern, already covered later in the file). Replaced the strong_parameters mention with `attr_accessible` → `protected_attributes`, a real "switch to an alternative" example for the Rails 3 → 4 mass-assignment migration. (Suggested directly by the user during the review.)

4. **`9589372` Fix incorrect rationale for retry_after_seconds tracking** — the Polling section said "Track elapsed time across the polls (the server's `retry_after_seconds` can grow)." The server actually returns a constant value derived from gem count + concurrency (both fixed for a given lockfile). The "track elapsed time" instruction is still right (the 30-min cap needs it) but the rationale was wrong. Reworded to give the correct reason and clarify the relationship between the 10-poll and 30-minute caps.

5. **`863c402` Add Step 4.5 (Check Gem Compatibility) to Pattern 1** — PR #49 added Step 4.5 to the High-Level Workflow but Pattern 1 in `## Common Request Patterns` had no corresponding entry, so the two sections of `SKILL.md` disagreed on whether the compatibility check is part of the upgrade flow. Added the entry between Pattern 1's Step 4 (Run Detection) and Step 5 (Generate Reports), pointing at `workflows/gem-compatibility-workflow.md`. Pattern 2's "Pattern 1 Steps 4-6" cross-reference covers 4.5 by inclusive-range convention; Pattern 3 (analysis-only) intentionally skips this — running a compatibility check on a non-committal analysis flow would be premature work.

6. **`748badd` Add stale-lockfile re-POST + bundle_report parser-miss guards** — two edge cases the workflow didn't handle. **a)** `bundle_report` parser miss: if a future `next_rails` release reformats the output, the regex parse would silently produce empty buckets and the agent would report "all gems compatible" — wrong-and-confident is the worst failure mode for a compatibility check. Now: if no `=> incompatible with rails X` headers are found despite exit 0, escalate to the secondary check. **b)** Stale lockfile: if the agent runs `bundle install` / `bundle update` mid-session and re-checks compatibility, the cached railsbump slug is for the old lockfile. Added explicit "re-POST when the lockfile changes" guidance.

## Test plan

- [ ] Render `gem-compatibility-workflow.md` and confirm the four code blocks (POST, GET, sample bundle_report output, lockfile_check JSON) still render
- [ ] Walk an upgrade with `bundle_report` available and confirm Pattern 1 Step 4.5 fires between Detection and Generate Reports
- [ ] Walk an upgrade where `bundle_report` is missing or returns malformed output and confirm escalation to railsbump per the new guard
- [ ] Sanity check that the "unresolved → blockers (pending information)" path produces a usable user-facing message rather than a silent skip
