### PR TITLE
Classify kind: for rails-41-patterns.yml (#56)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 4.0 → 4.1 upgrade"
 breaking_changes:
   high_priority:
     - name: "Dynamic finders (find_all_by / find_last_by / scoped_by / find_by)"
+      kind: breaking
       pattern: "\\.(find_all_by_|find_last_by_|scoped_by_|find_by_)[a-zA-Z_0-9]+!?"
       exclude: "\\.find_by\\s*\\("
       search_paths:
@@ -14,6 +15,7 @@ breaking_changes:
       variable_name: "DYNAMIC_FINDERS"
 
     - name: "Dynamic find_or_initialize_by_* / find_or_create_by_*"
+      kind: breaking
       pattern: "\\.(find_or_initialize_by_|find_or_create_by_)[a-zA-Z_0-9]+"
       exclude: ""
       search_paths:
@@ -24,6 +26,7 @@ breaking_changes:
       variable_name: "FIND_OR_X_BY_DYNAMIC"
 
     - name: "return inside inline callback block"
+      kind: breaking
       pattern: "^\\s*(before_|after_|around_)(save|create|update|destroy|validation|commit|rollback|initialize|find|touch)\\b.*\\{[^}]*\\breturn\\b"
       exclude: ""
       search_paths:
@@ -35,6 +38,7 @@ breaking_changes:
       variable_name: "CALLBACK_RETURN"
 
     - name: "Implicit join reference in includes+where string"
+      kind: breaking
       pattern: "\\.includes\\([^)]+\\)[^\\n]*\\.where\\(\\s*['\"][a-z_][a-z_0-9]*\\."
       exclude: "\\.references\\(|\\.eager_load\\("
       search_paths:
@@ -45,6 +49,7 @@ breaking_changes:
       variable_name: "IMPLICIT_JOIN_REFERENCES"
 
     - name: "store_accessor on json/hstore column (PG key semantics)"
+      kind: breaking
       pattern: "^\\s*store_accessor\\s+:"
       exclude: ""
       search_paths:
@@ -54,6 +59,7 @@ breaking_changes:
       variable_name: "PG_JSON_HSTORE_KEYS"
 
     - name: "default_scope in models"
+      kind: breaking
       pattern: "^\\s*default_scope\\b"
       exclude: ""
       search_paths:
@@ -64,6 +70,7 @@ breaking_changes:
 
   medium_priority:
     - name: "MultiJSON usage"
+      kind: breaking
       pattern: "\\bMultiJSON\\b|require\\s+['\"]multi_json['\"]"
       exclude: ""
       search_paths:
@@ -75,6 +82,7 @@ breaking_changes:
       variable_name: "MULTI_JSON"
 
     - name: "ActiveRecord::Relation mutator calls"
+      kind: breaking
       pattern: "\\.(compact!|map!|delete_if|reject!|select!|flatten!|sort!|uniq!|collect!)\\b"
       exclude: ""
       search_paths:
@@ -85,6 +93,7 @@ breaking_changes:
       variable_name: "RELATION_MUTATORS"
 
     - name: "Controller test with format: :js (should use xhr)"
+      kind: breaking
       pattern: "^\\s*(get|post|put|patch|delete)\\s+:[a-z_]+[^\\n]*format:\\s*:js"
       exclude: "\\bxhr\\b"
       search_paths:
@@ -96,6 +105,7 @@ breaking_changes:
       variable_name: "JS_CONTROLLER_TEST"
 
     - name: "flash.to_hash with symbol key filters"
+      kind: breaking
       pattern: "flash\\.to_hash\\.(except|slice|values_at)\\(\\s*:"
       exclude: ""
       search_paths:
@@ -105,6 +115,7 @@ breaking_changes:
       variable_name: "FLASH_SYMBOL_KEYS"
 
     - name: "Cookies serializer not configured"
+      kind: optional
       pattern: "cookies_serializer"
       exclude: ""
       search_paths:
@@ -114,6 +125,7 @@ breaking_changes:
       variable_name: "COOKIES_SERIALIZER"
 
     - name: "I18n enforce_available_locales config"
+      kind: breaking
       pattern: "enforce_available_locales|available_locales"
       exclude: ""
       search_paths:
@@ -123,6 +135,7 @@ breaking_changes:
       variable_name: "I18N_ENFORCE_LOCALES"
 
     - name: "time_precision (as_json millisecond default)"
+      kind: migration
       pattern: "time_precision"
       exclude: ""
       search_paths:
@@ -133,6 +146,7 @@ breaking_changes:
 
   low_priority:
     - name: "Spring gem in Gemfile (presence check)"
+      kind: optional
       pattern: "gem\\s+['\"]spring['\"]"
       exclude: ""
       search_paths:
@@ -142,6 +156,7 @@ breaking_changes:
       variable_name: "SPRING"
 
     - name: "Legacy secret_key_base / secret_token reads"
+      kind: migration
       pattern: "Rails\\.application\\.config\\.secret_(key_base|token)"
       exclude: ""
       search_paths:
@@ -152,6 +167,7 @@ breaking_changes:
       variable_name: "SECRETS_CONFIG_READS"
 
     - name: "render :text usage"
+      kind: migration
       pattern: "\\brender\\s*[\\(\\s]\\s*(?:.*,\\s*)?(?:text:\\s*|:text\\s*=>)"
       exclude: ""
       search_paths:
@@ -161,6 +177,7 @@ breaking_changes:
       variable_name: "RENDER_TEXT"
 
     - name: "encode_json hook override"
+      kind: breaking
       pattern: "def\\s+encode_json\\b"
       exclude: ""
       search_paths:
@@ -171,6 +188,7 @@ breaking_changes:
       variable_name: "ENCODE_JSON_HOOK"
 
     - name: "encode_big_decimal_as_string (dead setting)"
+      kind: migration
       pattern: "encode_big_decimal_as_string"
       exclude: ""
       search_paths:
@@ -180,6 +198,7 @@ breaking_changes:
       variable_name: "BIG_DECIMAL_AS_STRING"
 
     - name: "JSON.generate / JSON.dump on Rails objects"
+      kind: migration
       pattern: "\\bJSON\\.(generate|dump)\\b"
       exclude: ""
       search_paths:
@@ -190,6 +209,7 @@ breaking_changes:
       variable_name: "JSON_GEM_ISOLATION"
 
     - name: "set_callback around lambda with &block"
+      kind: breaking
       pattern: "set_callback\\s+.+,\\s*:around\\s*,\\s*->\\([^)]*&block"
       exclude: ""
       search_paths:
@@ -200,6 +220,7 @@ breaking_changes:
       variable_name: "SET_CALLBACK_AROUND"
 
     - name: "disable_implicit_join_references config (dead setting)"
+      kind: deprecation
       pattern: "disable_implicit_join_references"
       exclude: ""
       search_paths:
@@ -209,6 +230,7 @@ breaking_changes:
       variable_name: "DISABLE_IMPLICIT_JOIN_REFERENCES"
 
     - name: "ActiveRecord::Migration.check_pending! in test helper"
+      kind: optional
       pattern: "ActiveRecord::Migration\\.check_pending!"
       exclude: ""
       search_paths:


### PR DESCRIPTION
## Summary

Classifies the new `kind:` field for every pattern in `rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml` (Rails 4.0 → 4.1 hop, 22 entries). Part of the schema rollout tracked in #53; closes sub-issue #56.

## Classification breakdown

| variable_name | kind | rationale |
|---|---|---|
| DYNAMIC_FINDERS | breaking | `find_all_by_*` etc. removed; raises NoMethodError without bridge gem. |
| FIND_OR_X_BY_DYNAMIC | breaking | Dynamic `find_or_*_by_<col>` forms removed; raises. |
| CALLBACK_RETURN | breaking | `return` inside inline callback block now raises LocalJumpError. |
| IMPLICIT_JOIN_REFERENCES | breaking | String-parsing heuristic removed; queries raise without explicit `references`. |
| PG_JSON_HSTORE_KEYS | breaking | json/hstore now string-keyed; symbol indexing silently returns nil (data-correctness break). |
| DEFAULT_SCOPE | breaking | Default scope now ANDs with subsequent scopes; can silently return zero rows. |
| MULTI_JSON | breaking | Rails no longer pulls in `multi_json`; direct callers raise NameError. |
| RELATION_MUTATORS | breaking | Mutator methods removed from `ActiveRecord::Relation`; raises NoMethodError. |
| JS_CONTROLLER_TEST | breaking | CSRF protection extended to JS GETs; existing tests fail. |
| FLASH_SYMBOL_KEYS | breaking | `flash.to_hash` keys are strings; symbol filters silently no-op (correctness break). |
| COOKIES_SERIALIZER | optional | New JSON serializer is opt-in for upgraded apps; `:hybrid` recommended but not required. |
| I18N_ENFORCE_LOCALES | breaking | `enforce_available_locales` defaults to true; unknown locales raise `I18n::InvalidLocale`. |
| JSON_TIME_PRECISION | migration | New default adds milliseconds; no warning, recommended to set explicitly to match client expectations. |
| SPRING | optional | Ships as new default for new apps; existing apps may add it but need not. |
| SECRETS_CONFIG_READS | migration | Old `secret_token` API still works; `secrets.yml` is the recommended forward path. |
| RENDER_TEXT | migration | `render :text` still works in 4.1; `:plain` / `:html` / `:body` are the recommended replacements ahead of later deprecation. |
| ENCODE_JSON_HOOK | breaking | New encoder no longer calls `encode_json`; custom impls become silently dead (correctness break). |
| BIG_DECIMAL_AS_STRING | migration | Setting is a no-op; cosmetic cleanup, no warning emitted. |
| JSON_GEM_ISOLATION | migration | `JSON.generate`/`dump` no longer honor `as_json`; recommended migration to `to_json` for Rails objects. |
| SET_CALLBACK_AROUND | breaking | Around-callback lambda signature changed; old `&block` form will misbehave. |
| DISABLE_IMPLICIT_JOIN_REFERENCES | deprecation | Setting is a no-op and emits a deprecation warning at runtime. |
| CHECK_PENDING_MIGRATION | optional | Explicit call is harmless but redundant; cleanup only. |

Totals: breaking 13, deprecation 1, migration 5, optional 3.

### Borderline calls

- **JSON_TIME_PRECISION** — could be argued `breaking` (silent serialization change with potential client impact), but Rails itself does not raise or warn, and the explanation frames it as a default to consciously accept or override. Classed as `migration` (recommended path).
- **RENDER_TEXT** — explanation says it "signals :text for future deprecation" but does not state Rails 4.1 emits a warning. Treated as `migration`; will become `deprecation` proper in the 4.1 → 4.2 entry.
- **PG_JSON_HSTORE_KEYS / FLASH_SYMBOL_KEYS / DEFAULT_SCOPE** — silent semantic shifts rather than raises. Classed as `breaking` per the rubric ("silently wrong behavior with production impact").

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml` passes
- [x] `bin/validate-patterns` (all files) passes

## Linked issues

Refs #53
Closes #56
