### PR TITLE
Classify kind: for rails-50-patterns.yml (#58)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 4.2 → 5.0 upgrade"
 breaking_changes:
   high_priority:
     - name: "Ruby version below 2.2.2"
+      kind: "breaking"
       pattern: "ruby.*['\"]2\\.[01]\\.|ruby.*['\"]1\\."
       exclude: ""
       search_paths:
@@ -14,6 +15,7 @@ breaking_changes:
       variable_name: "RUBY_VERSION"
 
     - name: "Models inheriting from ActiveRecord::Base"
+      kind: "migration"
       pattern: "class\\s+\\w+\\s*<\\s*ActiveRecord::Base"
       exclude: "ApplicationRecord"
       search_paths:
@@ -23,6 +25,7 @@ breaking_changes:
       variable_name: "ACTIVERECORD_BASE"
 
     - name: "belongs_to without optional: true"
+      kind: "migration"
       pattern: "belongs_to\\s+:\\w+"
       exclude: "optional:"
       search_paths:
@@ -32,6 +35,7 @@ breaking_changes:
       variable_name: "BELONGS_TO_REQUIRED"
 
     - name: "protected_attributes gem"
+      kind: "breaking"
       pattern: "gem.*['\"]protected_attributes['\"]"
       exclude: ""
       search_paths:
@@ -41,6 +45,7 @@ breaking_changes:
       variable_name: "PROTECTED_ATTRIBUTES"
 
     - name: "attr_accessible in models"
+      kind: "breaking"
       pattern: "attr_accessible"
       exclude: ""
       search_paths:
@@ -50,6 +55,7 @@ breaking_changes:
       variable_name: "ATTR_ACCESSIBLE"
 
     - name: "Parameters used as hash"
+      kind: "breaking"
       pattern: "params(\\[.*\\])?\\.(slice|except|merge|symbolize_keys|to_hash)\\b"
       exclude: ""
       search_paths:
@@ -61,6 +67,7 @@ breaking_changes:
 
   medium_priority:
     - name: "Callback returning false to halt"
+      kind: "deprecation"
       pattern: "return\\s+false"
       exclude: ""
       search_paths:
@@ -71,6 +78,7 @@ breaking_changes:
       variable_name: "CALLBACK_HALT"
 
     - name: "assigns in tests"
+      kind: "breaking"
       pattern: "assigns\\(:"
       exclude: ""
       search_paths:
@@ -81,6 +89,7 @@ breaking_changes:
       variable_name: "ASSIGNS_IN_TESTS"
 
     - name: "assert_template in tests"
+      kind: "breaking"
       pattern: "assert_template"
       exclude: ""
       search_paths:
@@ -91,6 +100,7 @@ breaking_changes:
       variable_name: "ASSERT_TEMPLATE"
 
     - name: "ActionDispatch::Http::UploadedFile in tests"
+      kind: "migration"
       pattern: "ActionDispatch::Http::UploadedFile"
       exclude: ""
       search_paths:
@@ -101,6 +111,7 @@ breaking_changes:
       variable_name: "UPLOAD_FILE_TEST"
 
     - name: "redirect_to :back deprecated"
+      kind: "deprecation"
       pattern: "redirect_to\\s+:back\\b"
       exclude: ""
       search_paths:
@@ -110,6 +121,7 @@ breaking_changes:
       variable_name: "REDIRECT_TO_BACK_DEPRECATED"
 
     - name: "rake commands in scripts or docs"
+      kind: "migration"
       pattern: "\\brake\\s+(db:|test|routes|assets:|secret)"
       exclude: ""
       search_paths:


### PR DESCRIPTION
## Summary

Classifies the `kind:` field for every pattern in `rails-50-patterns.yml` (12 patterns, Rails 4.2 → 5.0 hop). `kind:` is orthogonal to `priority` and captures *why* a pattern matters: won't bundle/boot (`breaking`), warns now / removed later (`deprecation`), recommended migration target (`migration`), or opt-in (`optional`). Refs #53, closes #58.

## Counts

| kind        | count |
|-------------|-------|
| breaking    | 6     |
| deprecation | 2     |
| migration   | 4     |
| optional    | 0     |
| **total**   | **12**|

## Per-pattern classification

| variable_name                 | kind        | rationale |
|-------------------------------|-------------|-----------|
| `RUBY_VERSION`                | breaking    | Rails 5.0 requires Ruby >= 2.2.2; older Ruby fails to bundle. |
| `ACTIVERECORD_BASE`           | migration   | `ApplicationRecord` is the new convention; `ActiveRecord::Base` still works without warning at 5.0. |
| `BELONGS_TO_REQUIRED`         | migration   | Required-by-default is gated by `belongs_to_required_by_default` in `new_framework_defaults_5_0.rb`; version bump alone doesn't flip it. |
| `PROTECTED_ATTRIBUTES`        | breaking    | `protected_attributes` gem is incompatible with Rails 5.0; bundling fails. |
| `ATTR_ACCESSIBLE`             | breaking    | `attr_accessible` is removed in Rails 5.0; raises at load. |
| `PARAMS_AS_HASH`              | breaking    | `params` is no longer a `HashWithIndifferentAccess`; hash methods raise at runtime. |
| `CALLBACK_HALT`               | deprecation | Returning `false` from `before_*` emits a deprecation warning in 5.0; removed in 5.1. |
| `ASSIGNS_IN_TESTS`            | breaking    | `assigns` extracted to `rails-controller-testing`; without the gem, controller tests fail. |
| `ASSERT_TEMPLATE`             | breaking    | Same extraction as `assigns`; controller tests fail without the gem. |
| `UPLOAD_FILE_TEST`            | migration   | `Rack::Test::UploadedFile` is the recommended replacement; old form still functions. |
| `REDIRECT_TO_BACK_DEPRECATED` | deprecation | Explicitly deprecated in 5.0 (warning), removed in 5.1. |
| `RAKE_COMMANDS`               | migration   | `rails` command is preferred; `rake db:migrate` etc. still work in 5.0. |

## Borderline calls

- **`ACTIVERECORD_BASE` → migration.** Could read as `breaking` since the upgrade methodology pushes ApplicationRecord, but `ActiveRecord::Base` inheritance still works at 5.0 without a deprecation warning. Treating as migration target.
- **`BELONGS_TO_REQUIRED` → migration.** Effectively `breaking` once `config.load_defaults 5.0` is set (which the rails-load-defaults skill handles), but at the raw 4.2 → 5.0 boundary it does not raise. Marking migration so the orchestrator surfaces it as a recommended target, not a hard blocker.
- **`RAKE_COMMANDS` → migration.** `rake` invocations still work; this is a preference, not a break. Could be argued as `optional` but the `fix` field treats it as a recommended swap.
- **`CALLBACK_HALT` → deprecation.** Tempting to mark `breaking` because of silently-wrong production impact, but Rails 5.0 emits a deprecation warning rather than silently failing; the breaking removal is at 5.1.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-50-patterns.yml` exits 0
- [x] `bin/validate-patterns` (all 12 files) exits 0
- [x] Spot-check via `grep -A1 "    - name:"` confirms `kind:` is the line immediately after each `name:`
- [x] No other field touched (`pattern`, `exclude`, `search_paths`, `explanation`, `fix`, `variable_name`, `dependencies:`)

Refs #53
Closes #58
