### PR TITLE
Classify kind: for rails-42-patterns.yml (#57)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-42-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-42-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 4.1 → 4.2 upgrade"
 breaking_changes:
   high_priority:
     - name: "ActionMailer .deliver / .deliver! deprecated"
+      kind: "deprecation"
       pattern: "\\.deliver!?\\s*(#|$)"
       exclude: ""
       search_paths:
@@ -14,6 +15,7 @@ breaking_changes:
       variable_name: "MAILER_DELIVER"
 
     - name: "respond_with usage"
+      kind: "breaking"
       pattern: "\\brespond_with\\b"
       exclude: ""
       search_paths:
@@ -23,6 +25,7 @@ breaking_changes:
       variable_name: "RESPOND_WITH"
 
     - name: "Class-level respond_to declaration"
+      kind: "breaking"
       pattern: "^\\s*respond_to\\s+:"
       exclude: ""
       search_paths:
@@ -32,6 +35,7 @@ breaking_changes:
       variable_name: "CLASS_RESPOND_TO"
 
     - name: "Verify raise_in_transactional_callbacks is configured"
+      kind: "deprecation"
       pattern: "class\\s+\\w+\\s*<\\s*Rails::Application"
       exclude: ""
       search_paths:
@@ -41,6 +45,7 @@ breaking_changes:
       variable_name: "TRANSACTIONAL_CALLBACKS"
 
     - name: "RSpec 2.x in Gemfile"
+      kind: "breaking"
       pattern: "rspec-rails.*['\"\\(][~><=\\s]*2\\."
       exclude: ""
       search_paths:
@@ -51,6 +56,7 @@ breaking_changes:
       variable_name: "RSPEC_2"
 
     - name: "assert_tag / TagAssertions"
+      kind: "deprecation"
       pattern: "\\bassert_tag\\b"
       exclude: ""
       search_paths:
@@ -61,6 +67,7 @@ breaking_changes:
       variable_name: "ASSERT_TAG"
 
     - name: "ActiveJob usage requires queue adapter"
+      kind: "migration"
       pattern: "\\.deliver_later\\b|<\\s*ActiveJob::Base\\b"
       exclude: ""
       search_paths:
@@ -72,6 +79,7 @@ breaking_changes:
 
   medium_priority:
     - name: "find/exists? with possible AR object argument"
+      kind: "deprecation"
       pattern: "\\.(find|exists\\?)\\(\\s*@?[a-z_][a-zA-Z_0-9.]*\\s*\\)"
       exclude: "\\.(find|exists\\?)\\([^)]*\\.id\\s*\\)|\\.(find|exists\\?)\\(\\s*\\d+"
       search_paths:
@@ -82,6 +90,7 @@ breaking_changes:
       variable_name: "FIND_WITH_OBJECT"
 
     - name: "HTML sanitizer usage"
+      kind: "breaking"
       pattern: "\\b(sanitize|strip_tags|strip_links|sanitize_css)\\b"
       exclude: ""
       search_paths:
@@ -91,6 +100,7 @@ breaking_changes:
       variable_name: "HTML_SANITIZER"
 
     - name: "Verify test_order is set"
+      kind: "deprecation"
       pattern: "Rails\\.application\\.configure"
       exclude: ""
       search_paths:
@@ -100,6 +110,7 @@ breaking_changes:
       variable_name: "TEST_ORDER"
 
     - name: "Serialized attributes with custom coder"
+      kind: "breaking"
       pattern: "serialize\\s+:\\w+,\\s*(JSON|YAML|\\w+Coder)"
       exclude: ""
       search_paths:
@@ -109,6 +120,7 @@ breaking_changes:
       variable_name: "SERIALIZED_CUSTOM_CODER"
 
     - name: "serve_static_assets config"
+      kind: "deprecation"
       pattern: "serve_static_assets"
       exclude: ""
       search_paths:
@@ -118,6 +130,7 @@ breaking_changes:
       variable_name: "SERVE_STATIC_ASSETS"
 
     - name: "form_authenticity_token in non-Rails forms"
+      kind: "breaking"
       pattern: "form_authenticity_token"
       exclude: ""
       search_paths:
@@ -127,6 +140,7 @@ breaking_changes:
       variable_name: "CSRF_TOKEN_MASKING"
 
     - name: "Foreigner gem"
+      kind: "migration"
       pattern: "gem.*['\"]foreigner['\"]"
       exclude: ""
       search_paths:
@@ -137,6 +151,7 @@ breaking_changes:
 
   low_priority:
     - name: "Procfile rails server without explicit bind"
+      kind: "breaking"
       pattern: "rails\\s+s(erver)?\\s*$|rails\\s+s(erver)?\\s+(?!-b|--binding)"
       exclude: "-b\\s+0\\.0\\.0\\.0|--binding"
       search_paths:
@@ -147,6 +162,7 @@ breaking_changes:
       variable_name: "SERVER_BIND"
 
     - name: "Timecop gem in use"
+      kind: "migration"
       pattern: "gem.*['\"]timecop['\"]|\\bTimecop\\."
       exclude: ""
       search_paths:


### PR DESCRIPTION
## Summary

Sub-issue #57 of the issue #53 rollout. Classifies the new `kind:` field for every pattern in `rails-upgrade/detection-scripts/patterns/rails-42-patterns.yml` (16 patterns total — Rails 4.1 → 4.2 hop). `kind:` is placed immediately after `name:`. No other fields touched; `dependencies:` section unchanged.

## Counts

| Kind | Count |
|---|---|
| `breaking` | 7 |
| `deprecation` | 6 |
| `migration` | 3 |
| `optional` | 0 |

## Classification rationale

### HIGH priority

| Variable | Kind | Why |
|---|---|---|
| `MAILER_DELIVER` | deprecation | In-file explanation: "deprecates .deliver / .deliver!"; removed in 5.2 |
| `RESPOND_WITH` | breaking | Extracted to `responders` gem — `NoMethodError` without it |
| `CLASS_RESPOND_TO` | breaking | Same — extracted |
| `TRANSACTIONAL_CALLBACKS` | deprecation | 4.2 emits a deprecation warning when not configured; default flips at 5.0 |
| `RSPEC_2` | breaking | Rails 4.2 incompatible with RSpec 2 — test suite won't run |
| `ASSERT_TAG` | deprecation | Explanation explicitly says "deprecated in Rails 4.2" |
| `ACTIVE_JOB_ADAPTER` | migration | Default `:inline` works; configuring a real adapter is the recommended prod path with no warning |

### MEDIUM priority

| Variable | Kind | Why |
|---|---|---|
| `FIND_WITH_OBJECT` | deprecation | Explanation: "deprecates passing AR objects" |
| `HTML_SANITIZER` | breaking | Silent semantic shift — Loofah-based output differs in edge cases (XSS / UX risk) |
| `TEST_ORDER` | deprecation | Explanation: "emits a deprecation warning when not set" |
| `SERIALIZED_CUSTOM_CODER` | breaking | Silent semantic shift — `nil` now persists as NULL instead of going through the coder |
| `SERVE_STATIC_ASSETS` | deprecation | Config rename; old key warns until 5.0 removal |
| `CSRF_TOKEN_MASKING` | breaking | Silent shift — per-request masking breaks non-Rails clients/forms that cache the token |
| `FOREIGNER` | migration | Foreigner still works; native FK support is the recommended path forward |

### LOW priority

| Variable | Kind | Why |
|---|---|---|
| `SERVER_BIND` | breaking | Silent default flip from `0.0.0.0` to `localhost`; Docker/Vagrant/remote-access setups break until they opt back in |
| `TIMECOP` | migration | Built-in `travel`/`travel_to`/`travel_back` replace most use cases; both work, no warning |

## Borderline calls

- **`HTML_SANITIZER`, `SERIALIZED_CUSTOM_CODER`, `CSRF_TOKEN_MASKING`, `SERVER_BIND`** — all silent semantic shifts (no exception, no warning, behavior changes). Classified as `breaking` because the four `kind` values lack a "silent shift" bucket and `breaking` best matches the production impact (per CLAUDE.md "silently wrong with prod impact" rubric clause). If reviewer prefers, these could move to `deprecation` (since `rails-deprecated_sanitizer` is the listed escape hatch for the sanitizer case), but the change isn't actually deprecation-warned by Rails.
- **`ACTIVE_JOB_ADAPTER`** — borderline `migration` vs `optional`. Default `:inline` works without configuration. Classified as `migration` because most production apps need to configure a real adapter (recommended path); `optional` would understate the production risk.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-42-patterns.yml` passes
- [x] `bin/validate-patterns` (all 12 files) passes — no regression elsewhere
- [x] `kind:` placed immediately after `name:` in every entry
- [x] No other field touched; `dependencies:` section unchanged

## Linked issues

- Refs #53 (parent — schema-cleanup tracking)
- Closes #57
