### PR TITLE
Classify kind: for rails-52-patterns.yml (#60)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -101,7 +101,7 @@ breaking_changes:
       variable_name: "EVENT_REDIS_ADAPTER"
 
     - name: "Erubis template handler references"
-      kind: "deprecation"
+      kind: "breaking"
       pattern: "\\bErubis\\b|::Handlers::Erubis"
       exclude: ""
       search_paths:

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -32,7 +32,7 @@ breaking_changes:
       exclude: "class_name:\\s*['\"]"
       search_paths:
         - "app/models/"
-      explanation: "Rails 5.2 deprecates passing class objects (constants) to the :class_name option on associations. Passing the constant forces autoload of the target class at boot time and breaks Zeitwerk in 6.0+"
+      explanation: "Rails 5.2 removes support for passing class objects (constants) to the :class_name option on associations; doing so now raises ArgumentError ('A class was passed to `:class_name` but we are expecting a string.') when the reflection is built, typically at model class load time. Finishes the deprecation cycle that began in 5.1. Background: passing the constant forces autoload of the target class at boot time and breaks Zeitwerk in 6.0+"
       fix: "Quote the class name: belongs_to :owner, class_name: User → belongs_to :owner, class_name: 'User'. Same applies to has_one, has_many, and has_and_belongs_to_many"
       variable_name: "CLASS_NAME_CONSTANT"
 

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -119,7 +119,7 @@ breaking_changes:
       search_paths:
         - "app/models/"
         - "lib/"
-      explanation: "Rails 5.2 deprecates overriding ActiveRecord's quoted_id. Custom implementations were used by some legacy gems to coerce non-AR objects into queries; this is now handled via Type::Value#serialize and ActiveModel::Type"
+      explanation: "Rails 5.2 removes the respond_to?(:quoted_id) hook in AR's quoting pipeline (deprecated in 5.1). Defining `def quoted_id` on a model no longer raises and no longer warns -- Rails simply ignores it during query construction, so the custom logic becomes silently dead code with production impact. Custom implementations were used by some legacy gems to coerce non-AR objects into queries; this is now handled via Type::Value#serialize and ActiveModel::Type"
       fix: "Migrate the logic to a custom ActiveModel::Type (define #serialize / #cast) or accept the model's default quoting behavior"
       variable_name: "QUOTED_ID_METHOD"
 

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -27,7 +27,7 @@ breaking_changes:
       variable_name: "DYNAMIC_ROUTE_SEGMENTS"
 
     - name: "class_name option with unquoted constant"
-      kind: "deprecation"
+      kind: "breaking"
       pattern: "class_name:\\s*[A-Z][A-Za-z0-9_:]*"
       exclude: "class_name:\\s*['\"]"
       search_paths:

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -135,7 +135,7 @@ breaking_changes:
       variable_name: "VERIFY_METHOD_DEPRECATION"
 
     - name: "lock! on ActiveRecord object"
-      kind: "deprecation"
+      kind: "breaking"
       pattern: "\\.lock!(?=\\(|\\s|$)"
       exclude: ""
       search_paths:

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -37,7 +37,7 @@ breaking_changes:
       variable_name: "CLASS_NAME_CONSTANT"
 
     - name: "error_on_ignored_order_or_limit config (renamed)"
-      kind: "deprecation"
+      kind: "breaking"
       pattern: "error_on_ignored_order_or_limit"
       exclude: ""
       search_paths:

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -141,7 +141,7 @@ breaking_changes:
       search_paths:
         - "app/"
         - "lib/"
-      explanation: "Rails 5.2 emits a deprecation warning when #lock! is called on an AR record with unsaved changes (the lock silently discarded the changes in earlier versions). NOISY REGEX: matches every .lock! call site; most are correct usage on persisted records with no in-memory edits. Audit each match to confirm the receiver has been saved before the lock"
+      explanation: "Rails 5.2 raises a RuntimeError when #lock! is called on an AR record with unsaved changes ('Locking a record with unpersisted changes is not supported.'). Finishes the deprecation cycle that began in 5.1; before that the lock silently discarded the changes. NOISY REGEX: matches every .lock! call site; most are correct usage on persisted records with no in-memory edits. Audit each match to confirm the receiver has been saved before the lock"
       fix: "Save (or reload) before locking: record.save; record.lock!. If you intended to lock and then mutate, the correct order is record.lock! followed by the assignment + save"
       variable_name: "LOCK_BANG_UNPERSISTED"
 

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -108,7 +108,7 @@ breaking_changes:
         - "app/"
         - "config/"
         - "lib/"
-      explanation: "Rails 5.1 replaced the Erubis ERB handler with Erubi. Rails 5.2 still warns when Erubis is referenced. Most apps never touch this directly; explicit references usually come from gems registering custom handlers"
+      explanation: "Rails 5.1 replaced the Erubis ERB handler with Erubi. Rails 5.2 removes the Erubis handler entirely; references to ActionView::Template::Handlers::Erubis raise NameError ('uninitialized constant'). Most apps never touch this directly; explicit references usually come from gems registering custom handlers that have not been updated for 5.2"
       fix: "Replace ActionView::Template::Handlers::Erubis references with ActionView::Template::Handlers::ERB (which is now Erubi-backed). For gems that register Erubis explicitly, check for an updated gem version or open an issue upstream"
       variable_name: "ERUBIS_HANDLER"
 

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 5.1 → 5.2 upgrade"
 breaking_changes:
   high_priority:
     - name: "ActiveModel::Dirty methods after save"
+      kind: "deprecation"
       pattern: "\\b\\w+_(changed\\?|was)|\\.changes\\b|\\.changed\\?"
       exclude: "saved_change_to_|attribute_before_last_save|saved_changes"
       search_paths:
@@ -16,6 +17,7 @@ breaking_changes:
 
   medium_priority:
     - name: "Dynamic :controller / :action segments in routes"
+      kind: "deprecation"
       pattern: "\\b(:controller|:action)\\b"
       exclude: "controller:|action:|:controller\\s*=>|:action\\s*=>|action_dispatch|action_view|action_mailer|action_cable|action_pack|action_controller"
       search_paths:
@@ -25,6 +27,7 @@ breaking_changes:
       variable_name: "DYNAMIC_ROUTE_SEGMENTS"
 
     - name: "class_name option with unquoted constant"
+      kind: "deprecation"
       pattern: "class_name:\\s*[A-Z][A-Za-z0-9_:]*"
       exclude: "class_name:\\s*['\"]"
       search_paths:
@@ -34,6 +37,7 @@ breaking_changes:
       variable_name: "CLASS_NAME_CONSTANT"
 
     - name: "error_on_ignored_order_or_limit config (renamed)"
+      kind: "deprecation"
       pattern: "error_on_ignored_order_or_limit"
       exclude: ""
       search_paths:
@@ -43,6 +47,7 @@ breaking_changes:
       variable_name: "ERROR_ON_IGNORED_ORDER_OR_LIMIT"
 
     - name: "halt_callback_chains_on_return_false config (deprecated)"
+      kind: "deprecation"
       pattern: "halt_callback_chains_on_return_false"
       exclude: ""
       search_paths:
@@ -52,6 +57,7 @@ breaking_changes:
       variable_name: "HALT_CALLBACK_CHAINS_ON_RETURN_FALSE"
 
     - name: "String if:/unless: conditions on model callbacks"
+      kind: "deprecation"
       pattern: "(before|after|around)_(save|create|update|destroy|validation|commit|rollback|initialize|find|touch)\\b[^\\n]*\\b(if|unless):\\s*['\"]"
       exclude: ""
       search_paths:
@@ -61,6 +67,7 @@ breaking_changes:
       variable_name: "CALLBACK_STRING_CONDITIONS"
 
     - name: "Rails.application.secrets usage"
+      kind: "migration"
       pattern: "Rails\\.application\\.secrets\\b"
       exclude: ""
       search_paths:
@@ -73,6 +80,7 @@ breaking_changes:
 
   low_priority:
     - name: "Bootsnap gem in Gemfile (presence check)"
+      kind: "optional"
       pattern: "gem\\s+['\"]bootsnap['\"]"
       exclude: ""
       search_paths:
@@ -82,6 +90,7 @@ breaking_changes:
       variable_name: "BOOTSNAP_PRESENCE"
 
     - name: "event_redis ActionCable adapter"
+      kind: "deprecation"
       pattern: "event_redis"
       exclude: ""
       search_paths:
@@ -92,6 +101,7 @@ breaking_changes:
       variable_name: "EVENT_REDIS_ADAPTER"
 
     - name: "Erubis template handler references"
+      kind: "deprecation"
       pattern: "\\bErubis\\b|::Handlers::Erubis"
       exclude: ""
       search_paths:
@@ -103,6 +113,7 @@ breaking_changes:
       variable_name: "ERUBIS_HANDLER"
 
     - name: "Defining quoted_id method"
+      kind: "deprecation"
       pattern: "def\\s+quoted_id\\b"
       exclude: ""
       search_paths:
@@ -113,6 +124,7 @@ breaking_changes:
       variable_name: "QUOTED_ID_METHOD"
 
     - name: "ConnectionPool#verify with arguments"
+      kind: "deprecation"
       pattern: "\\.verify\\(\\s*\\S[^)]*\\)"
       exclude: ""
       search_paths:
@@ -123,6 +135,7 @@ breaking_changes:
       variable_name: "VERIFY_METHOD_DEPRECATION"
 
     - name: "lock! on ActiveRecord object"
+      kind: "deprecation"
       pattern: "\\.lock!(?=\\(|\\s|$)"
       exclude: ""
       search_paths:
@@ -133,6 +146,7 @@ breaking_changes:
       variable_name: "LOCK_BANG_UNPERSISTED"
 
     - name: "Legacy secret_key_base configuration"
+      kind: "deprecation"
       pattern: "Rails\\.application\\.config\\.secret_(token|key_base)"
       exclude: ""
       search_paths:

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -47,7 +47,7 @@ breaking_changes:
       variable_name: "ERROR_ON_IGNORED_ORDER_OR_LIMIT"
 
     - name: "halt_callback_chains_on_return_false config (deprecated)"
-      kind: "deprecation"
+      kind: "breaking"
       pattern: "halt_callback_chains_on_return_false"
       exclude: ""
       search_paths:

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -113,7 +113,7 @@ breaking_changes:
       variable_name: "ERUBIS_HANDLER"
 
     - name: "Defining quoted_id method"
-      kind: "deprecation"
+      kind: "breaking"
       pattern: "def\\s+quoted_id\\b"
       exclude: ""
       search_paths:

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -52,7 +52,7 @@ breaking_changes:
       exclude: ""
       search_paths:
         - "config/"
-      explanation: "Rails 5.2 deprecates config.active_support.halt_callback_chains_on_return_false. The `return false` halt mechanism was removed in Rails 5.0; the config has been a no-op since"
+      explanation: "Rails 5.2 removes ActiveSupport.halt_callback_chains_on_return_false entirely. The `return false` halt mechanism was removed in Rails 5.0; the config has been a no-op deprecated shim since 5.1 and is now gone. Assigning the config in config/application.rb or an initializer raises NoMethodError at boot"
       fix: "Remove the line entirely. Code that relied on `return false` to halt callbacks should already be using `throw :abort` after the 4.2 → 5.0 hop"
       variable_name: "HALT_CALLBACK_CHAINS_ON_RETURN_FALSE"
 

--- a/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml
@@ -42,7 +42,7 @@ breaking_changes:
       exclude: ""
       search_paths:
         - "config/"
-      explanation: "Rails 5.2 deprecates config.active_record.error_on_ignored_order_or_limit in favor of config.active_record.error_on_ignored_order"
+      explanation: "Rails 5.2 removes config.active_record.error_on_ignored_order_or_limit. The setting was renamed to config.active_record.error_on_ignored_order in 5.1 with a deprecated wrapper; the wrapper is gone in 5.2. Existing config lines using the old name raise NoMethodError at boot"
       fix: "Rename the config key: config.active_record.error_on_ignored_order_or_limit = X → config.active_record.error_on_ignored_order = X"
       variable_name: "ERROR_ON_IGNORED_ORDER_OR_LIMIT"
 


### PR DESCRIPTION
## Summary

Sub-issue #60 of the issue #53 rollout. Classifies the new `kind:` field for every pattern in `rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml` (14 patterns total — Rails 5.1 → 5.2 hop). `kind:` is placed immediately after `name:`. No other fields touched; `dependencies:` section unchanged.

Rails 5.2 finishes a sizable removal cycle for things deprecated in 5.0 / 5.1. The 5.2 CHANGELOGs are full of "Remove deprecated …" entries — six of those land in this file and are classified `breaking`. New deprecations introduced in 5.2 itself are lighter (matching the FastRuby.io characterization that *new* 5.2 deprecations are few), and those are classified `deprecation`.

## Counts

| Kind | Count |
|---|---|
| `breaking` | 6 |
| `deprecation` | 6 |
| `migration` | 1 |
| `optional` | 1 |
| **total** | **14** |

## Classification rationale

### HIGH priority

| Variable | Kind | Why |
|---|---|---|
| `DIRTY_TRACKING_AFTER_SAVE` | deprecation | At 5.2, calling `*_changed?` / `*_was` post-save emits a deprecation warning (warning text added in 5.1, still emitted at 5.2; removal in 6.0). Underlying semantic shift to "returns false/nil after save" landed at 5.1; at 5.2 the warning is the canonical signal. Priority stays HIGH because the wrong-output cases are silently broken in production code paths |

### MEDIUM priority

| Variable | Kind | Why |
|---|---|---|
| `DYNAMIC_ROUTE_SEGMENTS` | deprecation | At 5.2, `route_set.rb:594-606` emits `ActiveSupport::Deprecation.warn` for `:controller` and `:action` segments ("will be removed in Rails 6.0"). Same warning exists in 5.1; carried into 5.2 |
| `CLASS_NAME_CONSTANT` | **breaking** | At 5.2, `reflection.rb:435-437` raises `ArgumentError` ("A class was passed to `:class_name` but we are expecting a string."). 5.1 deprecation cycle finished; CHANGELOG: *"Remove deprecated support to passing a class to `:class_name` on associations."* |
| `ERROR_ON_IGNORED_ORDER_OR_LIMIT` | **breaking** | At 5.2, the `error_on_ignored_order_or_limit` accessor pair is removed (renamed to `error_on_ignored_order` in 5.1 with a deprecated wrapper). Old config line raises `NoMethodError` at boot. CHANGELOG: *"Remove deprecated configuration `.error_on_ignored_order_or_limit`."* |
| `HALT_CALLBACK_CHAINS_ON_RETURN_FALSE` | **breaking** | At 5.2, `ActiveSupport.halt_callback_chains_on_return_false` reader/writer methods are removed entirely (deprecated shim in 5.1, gone in 5.2). Setting in `config/application.rb` raises `NoMethodError` at boot. CHANGELOG: *"Remove deprecated `halt_callback_chains_on_return_false` option."* |
| `CALLBACK_STRING_CONDITIONS` | deprecation | String values for `:if`/`:unless` on model callbacks deprecated at 5.2 |
| `SECRETS_USAGE` | migration | `Rails.application.secrets` still works at 5.2 with no warning; `credentials.yml.enc` is the recommended path forward to avoid rework on the next hop |

### LOW priority

| Variable | Kind | Why |
|---|---|---|
| `BOOTSNAP_PRESENCE` | optional | New 5.2 default for boot speedup; opt-in performance gem |
| `EVENT_REDIS_ADAPTER` | deprecation | `:event_redis` ActionCable adapter deprecated at 5.2 |
| `ERUBIS_HANDLER` | **breaking** | At 5.2, the Erubis handler is removed entirely; the `erubis.rb` and `deprecated_erubis.rb` files present in 5.1 are gone in 5.2. Only `erubi.rb` remains. References to `ActionView::Template::Handlers::Erubis` raise `NameError` at autoload. CHANGELOG: *"Remove deprecated Erubis ERB handler."* |
| `QUOTED_ID_METHOD` | **breaking** | At 5.2, the `respond_to?(:quoted_id)` hook in AR's quoting pipeline is removed (deprecated in 5.1). Defining `def quoted_id` no longer raises but is silently dead — Rails ignores it during query construction. Same project convention as `HTML_SANITIZER` / `CSRF_TOKEN_MASKING` / `CACHE_KEY_FORMAT` from earlier-version files: silent semantic shift = `breaking`. CHANGELOG: *"Remove deprecated support to `quoted_id` when typecasting an Active Record object."* |
| `VERIFY_METHOD_DEPRECATION` | deprecation | Passing arguments to `ConnectionPool#verify` deprecated at 5.2 |
| `LOCK_BANG_UNPERSISTED` | **breaking** | At 5.2, `pessimistic.rb:63-71` raises `RuntimeError` ("Locking a record with unpersisted changes is not supported.") when `#lock!` is called on a dirty record. 5.1 deprecation cycle finished; CHANGELOG: *"Raises when calling `lock!` in a dirty record."* |
| `LEGACY_SECRET_KEY_BASE` | deprecation | `secrets.secret_token` reads emit deprecation warning at 5.2 |

## Source-verified flips during code review

Six entries were originally classified `deprecation` and were flipped to `breaking` during code review against `rails/rails` v5.1.0 vs v5.2.0 source. Each flip has its own commit with the specific file:line reference and CHANGELOG quote:

- `Flip CLASS_NAME_CONSTANT kind to breaking at 5.2`
- `Flip ERROR_ON_IGNORED_ORDER_OR_LIMIT kind to breaking at 5.2`
- `Flip HALT_CALLBACK_CHAINS_ON_RETURN_FALSE kind to breaking at 5.2`
- `Flip ERUBIS_HANDLER kind to breaking at 5.2`
- `Flip QUOTED_ID_METHOD kind to breaking at 5.2`
- `Flip LOCK_BANG_UNPERSISTED kind to breaking at 5.2`

A second pass reconciles each entry's `explanation:` text — the original strings still said "deprecates" / "emits a warning" after the flip. Six follow-up commits reconcile the wording entry-by-entry.

## Borderline calls

- **`DIRTY_TRACKING_AFTER_SAVE`** — borderline `deprecation` vs `breaking`. Rails 5.2 emits a deprecation warning, so `deprecation` matches the official signal at this hop. The underlying behavior (post-save returns `false`/`nil`) is silently wrong in production code paths, but `priority: HIGH` already captures that risk. Going with `deprecation` because the actual semantic shift to "returns false/nil after save" landed at 5.1 — labeling it `breaking` here would double-count what 5.1's classification covers.
- **`SECRETS_USAGE`** — `migration` rather than `deprecation` because `Rails.application.secrets` still works at 5.2 *without* a Rails-side deprecation warning.
- **`QUOTED_ID_METHOD`** — `breaking` via the silent-shift mechanism (Rails ignores the user method instead of raising). Same shape as `HTML_SANITIZER` / `CSRF_TOKEN_MASKING` / `CACHE_KEY_FORMAT` already in the codebase.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-52-patterns.yml` passes
- [x] `bin/validate-patterns` (all 12 files) passes — no regression elsewhere
- [x] `kind:` placed immediately after `name:` in every entry
- [x] No other field touched; `dependencies:` section unchanged
- [x] Six flipped entries source-verified against `rails/rails` v5.1.0 vs v5.2.0; commits include file:line references and CHANGELOG quotes
- [x] Six `explanation:` strings reconciled with the new `kind: breaking` so detection output is internally consistent

## Linked issues

- Refs #53 (parent — schema-cleanup tracking)
- Closes #60
