### PR TITLE
Classify kind: for rails-51-patterns.yml (#59)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 5.0 → 5.1 upgrade"
 breaking_changes:
   high_priority:
     - name: "render :text removed"
+      kind: "breaking"
       pattern: "\\brender\\s+(:text\\s*=>|text:)"
       exclude: ""
       search_paths:
@@ -13,6 +14,7 @@ breaking_changes:
       variable_name: "RENDER_TEXT"
 
     - name: "render :nothing removed"
+      kind: "breaking"
       pattern: "\\brender\\s+(:nothing\\s*=>|nothing:)"
       exclude: ""
       search_paths:
@@ -22,6 +24,7 @@ breaking_changes:
       variable_name: "RENDER_NOTHING"
 
     - name: "redirect_to :back removed"
+      kind: "breaking"
       pattern: "redirect_to\\s+:back\\b"
       exclude: ""
       search_paths:
@@ -31,6 +34,7 @@ breaking_changes:
       variable_name: "REDIRECT_TO_BACK"
 
     - name: "*_filter callback methods removed"
+      kind: "breaking"
       pattern: "\\b(before|after|around|skip_before|skip_after|skip_around|prepend_before|prepend_after|prepend_around|append_before|append_after|append_around)_filter\\b"
       exclude: ""
       search_paths:
@@ -41,6 +45,7 @@ breaking_changes:
       variable_name: "FILTER_METHODS"
 
     - name: "String conditions in controller filters"
+      kind: "breaking"
       pattern: "(before|after|around|skip_before|skip_after|skip_around|prepend_before|prepend_after|prepend_around|append_before|append_after|append_around)_(action|filter)\\b[^\\n]*\\b(if|unless):\\s*['\"]"
       exclude: ""
       search_paths:
@@ -50,6 +55,7 @@ breaking_changes:
       variable_name: "FILTER_STRING_CONDITIONS"
 
     - name: "ActiveRecord::Relation#uniq removed"
+      kind: "breaking"
       pattern: "\\.uniq(\\b|\\()"
       exclude: "\\.(to_a|map|pluck|select|reject|each|values|keys|compact)[^\\n]*\\.uniq"
       search_paths:
@@ -60,6 +66,7 @@ breaking_changes:
       variable_name: "RELATION_UNIQ"
 
     - name: "use_transactional_fixtures removed"
+      kind: "breaking"
       pattern: "use_transactional_fixtures"
       exclude: ""
       search_paths:
@@ -70,6 +77,7 @@ breaking_changes:
       variable_name: "USE_TRANSACTIONAL_FIXTURES"
 
     - name: "Controller test positional arguments"
+      kind: "breaking"
       pattern: "^\\s*(get|post|put|patch|delete|head)\\s+[:'\"][^,\\n]+,\\s*(\\{|[a-z_]+:)"
       exclude: "params:|session:|flash:|headers:|body:|xhr:|format:"
       search_paths:
@@ -83,6 +91,7 @@ breaking_changes:
 
   medium_priority:
     - name: "raise_in_transactional_callbacks config (dead setting)"
+      kind: "breaking"
       pattern: "raise_in_transactional_callbacks"
       exclude: ""
       search_paths:
@@ -92,6 +101,7 @@ breaking_changes:
       variable_name: "RAISE_IN_TRANSACTIONAL_CALLBACKS"
 
     - name: "serve_static_files config renamed"
+      kind: "breaking"
       pattern: "config\\.serve_static_files"
       exclude: ""
       search_paths:
@@ -101,6 +111,7 @@ breaking_changes:
       variable_name: "SERVE_STATIC_FILES_RENAME"
 
     - name: "static_cache_control config renamed"
+      kind: "breaking"
       pattern: "config\\.static_cache_control"
       exclude: ""
       search_paths:
@@ -110,6 +121,7 @@ breaking_changes:
       variable_name: "STATIC_CACHE_CONTROL_RENAME"
 
     - name: "application.secrets nested string-key access"
+      kind: "breaking"
       pattern: "Rails\\.application\\.secrets\\[[^\\]]+\\]\\[['\"]"
       exclude: ""
       search_paths:
@@ -121,6 +133,7 @@ breaking_changes:
       variable_name: "SECRETS_STRING_KEYS"
 
     - name: "application.secrets method-accessor string-key access"
+      kind: "breaking"
       pattern: "Rails\\.application\\.secrets\\.\\w+\\[['\"]"
       exclude: ""
       search_paths:


### PR DESCRIPTION
## Summary

Classifies the `kind:` field for every pattern in `rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml` (Rails 5.0 → 5.1 hop, 13 patterns). Part of parent #53; closes sub-issue #59.

`kind:` is inserted immediately after `name:` on each entry. No other fields, regexes, priority groupings, or the `dependencies:` section were touched.

## Counts

| kind | count |
|------|------:|
| breaking | 13 |
| deprecation | 0 |
| migration | 0 |
| optional | 0 |
| **total** | **13** |

## Per-pattern classification

| variable_name | kind | why |
|---|---|---|
| RENDER_TEXT | breaking | `render text:` removed in 5.1; raises ArgumentError. |
| RENDER_NOTHING | breaking | `render nothing:` removed in 5.1; raises ArgumentError. |
| REDIRECT_TO_BACK | breaking | `redirect_to :back` removed in 5.1; raises at runtime. |
| FILTER_METHODS | breaking | `*_filter` controller callbacks removed in 5.1; NoMethodError. |
| FILTER_STRING_CONDITIONS | breaking | String values for `if:`/`unless:` on filters no longer accepted; raises. |
| RELATION_UNIQ | breaking | `ActiveRecord::Relation#uniq` removed in 5.1. |
| USE_TRANSACTIONAL_FIXTURES | breaking | `use_transactional_fixtures` removed in 5.1 (renamed to `use_transactional_tests` in 5.0). |
| CONTROLLER_TEST_POSITIONAL | breaking | Positional args dropped from controller test helpers; tests fail to run. |
| RAISE_IN_TRANSACTIONAL_CALLBACKS | breaking | Config option removed in 5.1; assignment raises NoMethodError on boot. |
| SERVE_STATIC_FILES_RENAME | breaking | `config.serve_static_files=` removed in 5.1 (renamed to `config.public_file_server.enabled`). |
| STATIC_CACHE_CONTROL_RENAME | breaking | `config.static_cache_control=` removed in 5.1 (renamed to `config.public_file_server.headers`). |
| SECRETS_STRING_KEYS | breaking | secrets.yml loads with symbol keys in 5.1; nested string-key access silently returns nil — prior contract effectively removed. |
| SECRETS_METHOD_ACCESSOR_STRING_KEYS | breaking | Same as above for the method-accessor form. |

## Borderline calls

- **SECRETS_STRING_KEYS / SECRETS_METHOD_ACCESSOR_STRING_KEYS** — These don't raise; they silently return `nil`. They don't fit `deprecation` (no warning) or `migration` (this is not "still works"; it returns wrong values). Classified `breaking` because the string-key access path is effectively removed in 5.1, and the failure mode is silent production breakage of typical code paths.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml` exits 0
- [x] `bin/validate-patterns` (all files) exits 0
- [x] All 13 patterns have `kind:` immediately after `name:`
- [x] No other fields, priority groupings, or `dependencies:` section modified
- [x] No regex `pattern:` or `exclude:` value changed

Refs #53
Closes #59
