### PR TITLE
Classify kind: for rails-70-patterns.yml (#62)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 6.1 → 7.0 upgrade"
 breaking_changes:
   high_priority:
     - name: "Ruby version requirement"
+      kind: "breaking"
       pattern: "ruby.*['\"]2\\.[0-6]"
       exclude: ""
       search_paths:
@@ -14,6 +15,7 @@ breaking_changes:
       variable_name: "RUBY_VERSION"
 
     - name: "Webpacker usage"
+      kind: "migration"
       pattern: "webpacker|javascript_pack_tag"
       exclude: "importmap"
       search_paths:
@@ -25,6 +27,7 @@ breaking_changes:
       variable_name: "WEBPACKER"
 
     - name: "Spring usage"
+      kind: "optional"
       pattern: "gem ['\"]spring['\"]"
       exclude: ""
       search_paths:
@@ -34,6 +37,7 @@ breaking_changes:
       variable_name: "SPRING"
 
     - name: "form_with local option"
+      kind: "migration"
       pattern: "form_with.*local:\\s*(true|false)"
       exclude: ""
       search_paths:
@@ -43,6 +47,7 @@ breaking_changes:
       variable_name: "FORM_WITH_LOCAL"
 
     - name: "ActionController::Base.allow_forgery_protection"
+      kind: "migration"
       pattern: "allow_forgery_protection"
       exclude: ""
       search_paths:
@@ -55,6 +60,7 @@ breaking_changes:
 
   medium_priority:
     - name: "secrets.yml usage"
+      kind: "deprecation"
       pattern: "Rails\\.application\\.secrets"
       exclude: "credentials"
       search_paths:
@@ -66,6 +72,7 @@ breaking_changes:
       variable_name: "SECRETS_YML"
 
     - name: "ActiveRecord enum prefix/suffix"
+      kind: "migration"
       pattern: "enum.*:.*\\{"
       exclude: ""
       search_paths:
@@ -75,6 +82,7 @@ breaking_changes:
       variable_name: "ENUM_SYNTAX"
 
     - name: "image_tag skip_pipeline"
+      kind: "breaking"
       pattern: "image_tag.*skip_pipeline"
       exclude: ""
       search_paths:
@@ -85,6 +93,7 @@ breaking_changes:
       variable_name: "IMAGE_TAG_PIPELINE"
 
     - name: "ActiveStorage variant syntax"
+      kind: "deprecation"
       pattern: "\\.variant\\(.*resize:"
       exclude: ""
       search_paths:
@@ -94,6 +103,7 @@ breaking_changes:
       variable_name: "ACTIVE_STORAGE_VARIANT"
 
     - name: "Turbolinks"
+      kind: "migration"
       pattern: "turbolinks|Turbolinks"
       exclude: ""
       search_paths:
@@ -105,6 +115,7 @@ breaking_changes:
       variable_name: "TURBOLINKS"
 
     - name: "UJS (rails-ujs)"
+      kind: "migration"
       pattern: "rails-ujs|@rails/ujs"
       exclude: ""
       search_paths:
@@ -116,6 +127,7 @@ breaking_changes:
       variable_name: "RAILS_UJS"
 
     - name: "to_s(:format) deprecation"
+      kind: "deprecation"
       pattern: "\\.to_s\\(:"
       exclude: ""
       search_paths:

--- a/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
@@ -82,14 +82,14 @@ breaking_changes:
       variable_name: "ENUM_SYNTAX"
 
     - name: "image_tag skip_pipeline"
-      kind: "breaking"
+      kind: "optional"
       pattern: "image_tag.*skip_pipeline"
       exclude: ""
       search_paths:
         - "app/views/"
         - "app/helpers/"
-      explanation: "image_tag skip_pipeline option removed in Rails 7.0"
-      fix: "Remove skip_pipeline option from image_tag calls"
+      explanation: "skip_pipeline is fully supported at Rails 7.0; image_tag's implementation is byte-for-byte identical to 6.1. The option was actually expanded at 7.0 to also work on stylesheet_link_tag. This entry flags call sites for review when migrating away from Sprockets to Propshaft / Importmap, but the option itself does not change at this hop and existing calls continue to work"
+      fix: "No change required at the 7.0 hop. If you are also migrating off the Sprockets asset pipeline, audit each skip_pipeline call to confirm it is still doing what you intend under the new pipeline; otherwise leave as-is"
       variable_name: "IMAGE_TAG_PIPELINE"
 
     - name: "ActiveStorage variant syntax"

--- a/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
@@ -93,13 +93,13 @@ breaking_changes:
       variable_name: "IMAGE_TAG_PIPELINE"
 
     - name: "ActiveStorage variant syntax"
-      kind: "deprecation"
+      kind: "migration"
       pattern: "\\.variant\\(.*resize:"
       exclude: ""
       search_paths:
         - "app/"
-      explanation: "ActiveStorage variant syntax changes in Rails 7.0"
-      fix: "Use new syntax: variant(resize_to_limit: [100, 100])"
+      explanation: "Rails 7.0 makes vips the default variant processor for newly generated apps, but existing apps keep their previous setting (mini_magick) and the resize: form continues to work without any deprecation warning. activestorage/lib/active_storage/transformers/image_processing_transformer.rb is byte-for-byte identical between 6.1 and 7.0. If the app opts into vips by setting config.active_storage.variant_processor = :vips, then ImageMagick-flavored resize: arguments will fail at the libvips layer; that is a consequence of opting in, not a Rails-emitted deprecation"
+      fix: "If staying on mini_magick, no change required. If switching to vips (recommended for new apps), rewrite using libvips primitives: variant(resize_to_limit: [100, 100]), variant(resize_to_fill: [100, 100]), etc."
       variable_name: "ACTIVE_STORAGE_VARIANT"
 
     - name: "Turbolinks"

--- a/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
@@ -60,15 +60,15 @@ breaking_changes:
 
   medium_priority:
     - name: "secrets.yml usage"
-      kind: "deprecation"
+      kind: "migration"
       pattern: "Rails\\.application\\.secrets"
       exclude: "credentials"
       search_paths:
         - "app/"
         - "lib/"
         - "config/"
-      explanation: "Rails.application.secrets is deprecated in favor of credentials"
-      fix: "Migrate to Rails.application.credentials"
+      explanation: "Rails.application.secrets still works at 7.0 with no deprecation warning; def secrets in railties/lib/rails/application.rb is byte-for-byte identical to 6.1. The runtime API is officially deprecated in 7.1, so migrating to Rails.application.credentials at this hop avoids rework on the next one"
+      fix: "Move values from config/secrets.yml into config/credentials.yml.enc (`rails credentials:edit`), then update readers: Rails.application.secrets.api_key → Rails.application.credentials.api_key. config/master.key must NOT be committed"
       variable_name: "SECRETS_YML"
 
     - name: "ActiveRecord enum prefix/suffix"


### PR DESCRIPTION
## Summary

Classifies the new optional `kind:` field for every pattern in `rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml` (Rails 6.1 → 7.0 hop, 12 patterns). Part of the cross-version `kind:` rollout. Refs #53, Closes #62.

## Counts

| kind | count |
|------|-------|
| breaking | 1 |
| deprecation | 1 |
| migration | 9 |
| optional | 1 |
| **total** | **12** |

## Per-pattern classification

| variable_name | kind | rationale |
|---|---|---|
| `RUBY_VERSION` | breaking | Ruby 2.7+ required at 7.0 (`rails.gemspec:12: required_ruby_version = ">= 2.7.0"`); older Ruby prevents bundle / boot. |
| `WEBPACKER` | migration | Webpacker still works in 7.0 ("not maintained" but functional); Import Maps / jsbundling are the recommended path forward. |
| `SPRING` | optional | Spring is no longer included in newly generated Gemfiles, but existing apps that keep `gem "spring"` continue to work. |
| `FORM_WITH_LOCAL` | migration | `form_with` default flipped via `form_with_generates_remote_forms`, but `local: true/false` still works as an explicit option. Recommended migration target. |
| `FORGERY_PROTECTION` | migration | CSRF behavior shifted, but existing `protect_from_forgery` / `allow_forgery_protection` calls continue to load without warning. |
| `SECRETS_YML` | migration | `Rails.application.secrets` runtime API is byte-for-byte identical between 6.1 and 7.0; the deprecation lands in 7.1. Migrating now avoids rework on the next hop. |
| `ENUM_SYNTAX` | migration | Hash-form enum syntax is preferred; positional / keyword form continues to function without warning. |
| `IMAGE_TAG_PIPELINE` | optional | `skip_pipeline` is fully supported at 7.0 (implementation byte-for-byte identical to 6.1; option was actually expanded to `stylesheet_link_tag` at 7.0). The pattern is now a review prompt for users also migrating away from Sprockets, not a 7.0 break. |
| `ACTIVE_STORAGE_VARIANT` | migration | `vips` becomes the default variant processor for **new apps**, but existing apps keep their previous setting; the transformer source is byte-identical between 6.1 and 7.0 and emits no deprecation. Conditional break only if the user opts into `vips` and keeps the ImageMagick-flavored `resize:` form. |
| `TURBOLINKS` | migration | Turbolinks gem still works but Rails 7.0 ships Turbo as the recommended replacement. |
| `RAILS_UJS` | migration | rails-ujs still works; Turbo + Stimulus is the recommended replacement, no removal in 7.0. |
| `TO_S_FORMAT` | deprecation | At 7.0, `Array#to_s(:format)` / `Date#to_s(:format)` / etc. emit `ActiveSupport::Deprecation.warn` directly from `activesupport/lib/active_support/core_ext/*/deprecated_conversions.rb`; `to_fs` is the replacement. |

## Source-verified flips during code review

Three entries were flipped from the initial classification after verifying against `rails/rails` v6.1.0 vs v7.0.0. Each flip is one commit that bundles the `kind:` change with the reconciled `explanation:` and `fix:` text:

- `Flip SECRETS_YML kind to migration at 7.0 + reconcile copy` — runtime `Rails.application.secrets` API is unchanged at 7.0; the "deprecation" message in 7.0 source targets the `bin/rails secrets:setup` command, not the reader pattern this regex matches. Author had `deprecation`; flipped to `migration`.
- `Flip IMAGE_TAG_PIPELINE kind to optional at 7.0 + reconcile copy` — `skip_pipeline` was not removed; its `image_tag` implementation is byte-for-byte identical between 6.1 and 7.0, and 7.0 actually expanded the option to `stylesheet_link_tag`. Author had `breaking` ("calls raise"), and the original `explanation` / `fix` claimed removal that did not happen. Flipped to `optional` and rewrote the surrounding copy to match source.
- `Flip ACTIVE_STORAGE_VARIANT kind to migration at 7.0 + reconcile copy` — the variant transformer source is byte-identical between 6.1 and 7.0; there is no Rails-emitted deprecation for the `resize:` form at 7.0. The vips default is for new apps only. Author had `deprecation`; flipped to `migration`.

## Borderline calls

- **`FORM_WITH_LOCAL` (migration vs deprecation):** Default flipped via the `form_with_generates_remote_forms` config, no explicit deprecation warning on `local: true/false`. Treated as `migration` because the option still works without warning; users should revisit because the behavioral default changed.
- **`FORGERY_PROTECTION` (migration vs breaking):** CSRF defaults changed but existing `protect_from_forgery` / `allow_forgery_protection` calls continue to load. Classified `migration` because nothing raises; behavior is just different.
- **`WEBPACKER` (migration vs optional):** Could read as `optional` since Webpacker keeps working. Picked `migration` because the upstream gem is unmaintained and Rails 7.0 actively pushes apps off it.
- **`IMAGE_TAG_PIPELINE`:** Worth a separate follow-up — since nothing about `skip_pipeline` changes at 7.0, the entry may not belong in `rails-70-patterns.yml` at all. Out of scope for this PR; flagged here so the author of #69 / cleanup tracking can revisit.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml` exits 0
- [x] `bin/validate-patterns` (all 13 files) exits 0
- [x] `kind:` placed immediately after `name:` on every entry
- [x] No other fields, priority groupings, or `dependencies:` block touched outside the three flipped entries
- [x] Three flipped entries source-verified against `rails/rails` v6.1.0 vs v7.0.0; commits include file:line references and CHANGELOG quotes

Refs #53
Closes #62
