### PR TITLE
Classify kind: for rails-60-patterns.yml (#61)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-60-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-60-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 5.2 → 6.0 upgrade"
 breaking_changes:
   high_priority:
     - name: "require_dependency usage"
+      kind: "migration"
       pattern: "require_dependency"
       exclude: ""
       search_paths:
@@ -14,6 +15,7 @@ breaking_changes:
       variable_name: "REQUIRE_DEPENDENCY"
 
     - name: "Classic autoloader configuration"
+      kind: "deprecation"
       pattern: "config.autoloader\\s*=\\s*:classic"
       exclude: ""
       search_paths:
@@ -23,6 +25,7 @@ breaking_changes:
       variable_name: "CLASSIC_AUTOLOADER"
 
     - name: "ActiveRecord belongs_to required"
+      kind: "migration"
       pattern: "belongs_to.*optional:\\s*false"
       exclude: ""
       search_paths:
@@ -32,6 +35,7 @@ breaking_changes:
       variable_name: "BELONGS_TO_REQUIRED"
 
     - name: "protect_from_forgery"
+      kind: "migration"
       pattern: "protect_from_forgery.*with:\\s*:exception"
       exclude: ""
       search_paths:
@@ -41,6 +45,7 @@ breaking_changes:
       variable_name: "CSRF_PROTECTION"
 
     - name: "update_attributes deprecated"
+      kind: "deprecation"
       pattern: "update_attributes[^_]"
       exclude: "update_attribute"
       search_paths:
@@ -52,6 +57,7 @@ breaking_changes:
 
   medium_priority:
     - name: "ActionCable configuration"
+      kind: "migration"
       pattern: "config.action_cable"
       exclude: ""
       search_paths:
@@ -61,6 +67,7 @@ breaking_changes:
       variable_name: "ACTION_CABLE_CONFIG"
 
     - name: "ActiveStorage direct upload"
+      kind: "deprecation"
       pattern: "ActiveStorage::Blob\\.create_after_upload"
       exclude: ""
       search_paths:
@@ -71,6 +78,7 @@ breaking_changes:
       variable_name: "ACTIVE_STORAGE_UPLOAD"
 
     - name: "before_filter deprecated"
+      kind: "breaking"
       pattern: "before_filter"
       exclude: ""
       search_paths:
@@ -80,6 +88,7 @@ breaking_changes:
       variable_name: "BEFORE_FILTER"
 
     - name: "skip_before_filter deprecated"
+      kind: "breaking"
       pattern: "skip_before_filter"
       exclude: ""
       search_paths:
@@ -89,6 +98,7 @@ breaking_changes:
       variable_name: "SKIP_BEFORE_FILTER"
 
     - name: "render nothing: true"
+      kind: "breaking"
       pattern: "render.*nothing:\\s*true"
       exclude: ""
       search_paths:
@@ -98,6 +108,7 @@ breaking_changes:
       variable_name: "RENDER_NOTHING"
 
     - name: "Ruby version requirement"
+      kind: "breaking"
       pattern: "ruby.*['\"](?:1\\.|2\\.[0-4])"
       exclude: ""
       search_paths:
@@ -108,6 +119,7 @@ breaking_changes:
       variable_name: "RUBY_VERSION"
 
     - name: "Controller-level force_ssl deprecated"
+      kind: "deprecation"
       pattern: "^\\s*force_ssl\\b"
       exclude: ""
       search_paths:
@@ -117,6 +129,7 @@ breaking_changes:
       variable_name: "FORCE_SSL_DEPRECATED"
 
     - name: "Cookies metadata config (rollback compatibility)"
+      kind: "optional"
       pattern: "use_cookies_with_metadata"
       exclude: ""
       search_paths:
@@ -126,6 +139,7 @@ breaking_changes:
       variable_name: "COOKIES_METADATA_INCOMPATIBLE"
 
     - name: "Hosts authorization configuration"
+      kind: "breaking"
       pattern: "config\\.hosts\\b"
       exclude: ""
       search_paths:
@@ -135,6 +149,7 @@ breaking_changes:
       variable_name: "HOSTS_AUTHORIZATION_DEV"
 
     - name: "Legacy npm package names (actioncable / activestorage / rails-ujs)"
+      kind: "breaking"
       pattern: "['\"](actioncable|activestorage|rails-ujs)['\"]"
       exclude: "@rails/"
       search_paths:
@@ -145,6 +160,7 @@ breaking_changes:
       variable_name: "NPM_RAILS_PACKAGES"
 
     - name: "Rails.application.secrets.secret_token"
+      kind: "breaking"
       pattern: "Rails\\.application\\.secrets\\.secret_token\\b"
       exclude: ""
       search_paths:
@@ -156,6 +172,7 @@ breaking_changes:
       variable_name: "SECRETS_SECRET_TOKEN"
 
     - name: "fragment_cache_key helper"
+      kind: "breaking"
       pattern: "\\bfragment_cache_key\\b"
       exclude: "combined_fragment_cache_key"
       search_paths:
@@ -166,6 +183,7 @@ breaking_changes:
       variable_name: "FRAGMENT_CACHE_KEY"
 
     - name: "TestResponse predicate methods (success?/missing?/error?)"
+      kind: "breaking"
       pattern: "\\b(response|@response|last_response)\\.(success\\?|missing\\?|error\\?)"
       exclude: ""
       search_paths:
@@ -176,6 +194,7 @@ breaking_changes:
       variable_name: "TEST_RESPONSE_PREDICATES"
 
     - name: "ActiveRecord calculation methods with column name and block"
+      kind: "breaking"
       pattern: "\\.(count|sum)\\(\\s*:\\w+\\s*\\)\\s*(do\\b|\\{)"
       exclude: ""
       search_paths:
@@ -186,6 +205,7 @@ breaking_changes:
       variable_name: "AR_CALC_WITH_BLOCK"
 
     - name: "insert_fixtures adapter method"
+      kind: "breaking"
       pattern: "\\binsert_fixtures\\b"
       exclude: "insert_fixtures_set"
       search_paths:
@@ -197,6 +217,7 @@ breaking_changes:
       variable_name: "INSERT_FIXTURES_ADAPTER"
 
     - name: "ActiveRecord::Migrator.migrations_path setter"
+      kind: "breaking"
       pattern: "ActiveRecord::Migrator\\.migrations_path\\s*="
       exclude: ""
       search_paths:
@@ -209,6 +230,7 @@ breaking_changes:
 
   low_priority:
     - name: "image_alt view helper"
+      kind: "breaking"
       pattern: "\\bimage_alt\\b"
       exclude: ""
       search_paths:
@@ -219,6 +241,7 @@ breaking_changes:
       variable_name: "IMAGE_ALT_HELPER"
 
     - name: "Raw SQL strings in AR query methods"
+      kind: "breaking"
       pattern: "\\.(order|pluck|select|group)\\(\\s*['\"]"
       exclude: "Arel\\.sql"
       search_paths:
@@ -229,6 +252,7 @@ breaking_changes:
       variable_name: "AR_RAW_STRINGS"
 
     - name: "Direct Arel usage in queries"
+      kind: "deprecation"
       pattern: "\\bArel(::|\\.(?!sql\\b))"
       exclude: ""
       search_paths:
@@ -239,6 +263,7 @@ breaking_changes:
       variable_name: "AREL_DIRECT_USAGE"
 
     - name: "Dynamic :controller / :action segments in routes"
+      kind: "deprecation"
       pattern: "\\b(:controller|:action)\\b"
       exclude: "controller:|action:|action_dispatch|action_view|action_mailer|action_cable|action_pack|action_controller"
       search_paths:
@@ -248,6 +273,7 @@ breaking_changes:
       variable_name: "DYNAMIC_ROUTE_SEGMENTS"
 
     - name: "config.ru with application class"
+      kind: "deprecation"
       pattern: "^\\s*run\\s+\\w+::Application\\b"
       exclude: ""
       search_paths:
@@ -257,6 +283,7 @@ breaking_changes:
       variable_name: "CONFIG_RU_APP_CLASS"
 
     - name: "escape_attributes tag helper"
+      kind: "deprecation"
       pattern: "\\bescape_attributes\\b"
       exclude: ""
       search_paths:
@@ -267,6 +294,7 @@ breaking_changes:
       variable_name: "ESCAPE_ATTRIBUTES_HELPER"
 
     - name: "Transaction#set_state"
+      kind: "breaking"
       pattern: "\\.set_state\\("
       exclude: ""
       search_paths:


### PR DESCRIPTION
## Summary

Sub-issue #61 of the issue #53 rollout. Classifies the new `kind:` field for every pattern in `rails-upgrade/detection-scripts/patterns/rails-60-patterns.yml` (28 patterns total — Rails 5.2 → 6.0 hop). `kind:` is placed immediately after `name:`. No other fields touched; `dependencies:` section unchanged.

## Counts

| Kind | Count |
|---|---|
| `breaking` | 15 |
| `deprecation` | 8 |
| `migration` | 4 |
| `optional` | 1 |

## Classification rationale

### HIGH priority

| Variable | Kind | Why |
|---|---|---|
| `REQUIRE_DEPENDENCY` | migration | `require_dependency` still works under Zeitwerk in 6.0; no warning at this hop. Removal scheduled for later. Cleanup is recommended path |
| `CLASSIC_AUTOLOADER` | deprecation | In-file: "Classic autoloader is deprecated" |
| `BELONGS_TO_REQUIRED` | migration | Gated by `load_defaults 6.0`; not flipped by version bump alone. Recommended cleanup of redundant `optional: false` |
| `CSRF_PROTECTION` | migration | Same — gated by `load_defaults 6.0` |
| `UPDATE_ATTRIBUTES` | deprecation | In-file: "deprecated in Rails 6.0" |

### MEDIUM priority

| Variable | Kind | Why |
|---|---|---|
| `ACTION_CABLE_CONFIG` | migration | Vague FILE MARKER — "review settings for compatibility" |
| `ACTIVE_STORAGE_UPLOAD` | deprecation | `create_after_upload` deprecated in 6.0, removed in 6.1 |
| `BEFORE_FILTER` | breaking | Actually removed in Rails 5.1 (rails-51 patterns confirm); the in-file `explanation` saying "fully deprecated" is slightly stale |
| `SKIP_BEFORE_FILTER` | breaking | Same — removed in 5.1 |
| `RENDER_NOTHING` | breaking | Actually removed in 5.1 (rails-51 patterns: "removes `render nothing: true`"); in-file explanation here is stale |
| `RUBY_VERSION` | breaking | 6.0 won't boot on Ruby < 2.5 |
| `FORCE_SSL_DEPRECATED` | deprecation | In-file: "deprecates the controller-level `force_ssl`" |
| `COOKIES_METADATA_INCOMPATIBLE` | optional | Rollback-window concern only; ignorable for apps without a rollback path back to 5.2 |
| `HOSTS_AUTHORIZATION_DEV` | breaking | Silent default flip; non-localhost dev URLs return BlockedHost (HTTP 403) |
| `NPM_RAILS_PACKAGES` | breaking | Unscoped `actioncable` / `activestorage` / `rails-ujs` npm names unsupported — JS bundle breaks |
| `SECRETS_SECRET_TOKEN` | breaking | Legacy `secret_token` removed |
| `FRAGMENT_CACHE_KEY` | breaking | In-file: "removes the `fragment_cache_key` view helper" |
| `TEST_RESPONSE_PREDICATES` | breaking | In-file: "removes `#success?` / `#missing?` / `#error?`" |
| `AR_CALC_WITH_BLOCK` | breaking | In-file: "removes support for column + block" combo |
| `INSERT_FIXTURES_ADAPTER` | breaking | In-file: "removes `ConnectionAdapters#insert_fixtures`" |
| `MIGRATIONS_PATH_SETTER` | breaking | In-file: "removes `Migrator.migrations_path=`" |

### LOW priority

| Variable | Kind | Why |
|---|---|---|
| `IMAGE_ALT_HELPER` | breaking | In-file: "removes the `image_alt` view helper" |
| `AR_RAW_STRINGS` | breaking | Raises `ActiveRecord::UnknownAttributeReference` on unsafe SQL strings |
| `AREL_DIRECT_USAGE` | deprecation | In-file: "deprecates direct use of Arel methods outside `Arel.sql`" |
| `DYNAMIC_ROUTE_SEGMENTS` | deprecation | Carry-forward deprecation from 5.1 (catches apps that skipped that hop's detection) |
| `CONFIG_RU_APP_CLASS` | deprecation | In-file: "deprecates `run AppName::Application`" |
| `ESCAPE_ATTRIBUTES_HELPER` | deprecation | In-file: "deprecates the `escape_attributes` tag helper" |
| `SET_STATE_TRANSACTION` | breaking | In-file: "removes `Transaction#set_state`" |

## Borderline calls

- **`BEFORE_FILTER`, `SKIP_BEFORE_FILTER`, `RENDER_NOTHING`** — classified `breaking` despite the in-file `explanation` saying "deprecated" / "fully deprecated". These were actually **removed** in Rails 5.1 (the rails-51 patterns file has them as `breaking` per the explicit "removes" language). At 6.0 they remain removed. The in-file 6.0 explanations are stale and should be updated in a follow-up PR; for `kind:` here, going with the truth (removed) over the stale text. Reviewer can flip these to `deprecation` if they prefer to mirror the in-file wording until the explanation is fixed separately.
- **`REQUIRE_DEPENDENCY`** — `migration` rather than `deprecation` because at 6.0 the call still works under Zeitwerk without a deprecation warning. The Rails-side warning landed at a later hop. If reviewer recalls a 6.0 warning that I missed, this should flip to `deprecation`.
- **`COOKIES_METADATA_INCOMPATIBLE`** — `optional` because the only impact is on rollback compatibility. Apps without a rollback path back to 5.2 can ignore. Could plausibly be `migration` if rollback windows are seen as standard practice.
- **`HOSTS_AUTHORIZATION_DEV`, `NPM_RAILS_PACKAGES`** — both silent default flips with concrete failure modes (BlockedHost responses, broken JS bundles). Classified `breaking` per the silent-shift-with-prod-impact rubric clause.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-60-patterns.yml` passes
- [x] `bin/validate-patterns` (all 12 files) passes — no regression elsewhere
- [x] `kind:` placed immediately after `name:` in every entry
- [x] No other field touched; `dependencies:` section unchanged

## Linked issues

- Refs #53 (parent — schema-cleanup tracking)
- Closes #61
