### PR TITLE
Classify kind: for rails-71-patterns.yml (#63)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-71-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-71-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 7.0 → 7.1 upgrade"
 breaking_changes:
   high_priority:
     - name: "cache_classes deprecated"
+      kind: "deprecation"
       pattern: "cache_classes"
       exclude: ""
       search_paths:
@@ -13,6 +14,7 @@ breaking_changes:
       variable_name: "CACHE_CLASSES"
 
     - name: "legacy_connection_handling removed"
+      kind: "breaking"
       pattern: "legacy_connection_handling"
       exclude: ""
       search_paths:
@@ -22,6 +24,7 @@ breaking_changes:
       variable_name: "LEGACY_CONNECTION_HANDLING"
 
     - name: "preview_path singular deprecated"
+      kind: "deprecation"
       pattern: "preview_path\\s*="
       exclude: "preview_paths"
       search_paths:
@@ -31,6 +34,7 @@ breaking_changes:
       variable_name: "PREVIEW_PATH"
 
     - name: "Force SSL default changed"
+      kind: "optional"
       pattern: "force_ssl\\s*=\\s*false"
       exclude: ""
       search_paths:
@@ -40,6 +44,7 @@ breaking_changes:
       variable_name: "FORCE_SSL"
 
     - name: "lib/ autoloading changes"
+      kind: "optional"
       pattern: "autoload_paths.*lib|eager_load_paths.*lib"
       exclude: "autoload_lib"
       search_paths:
@@ -50,6 +55,7 @@ breaking_changes:
 
   medium_priority:
     - name: "SQLite database in db/ directory"
+      kind: "optional"
       pattern: "database:\\s*db/.*\\.sqlite3"
       exclude: ""
       search_paths:
@@ -59,6 +65,7 @@ breaking_changes:
       variable_name: "SQLITE_LOCATION"
 
     - name: "Query log tags configuration"
+      kind: "optional"
       pattern: "query_log_tags_enabled"
       exclude: ""
       search_paths:
@@ -68,6 +75,7 @@ breaking_changes:
       variable_name: "QUERY_LOG_TAGS"
 
     - name: "inspect output dependency"
+      kind: "migration"
       pattern: "\\.inspect"
       exclude: ""
       search_paths:
@@ -78,6 +86,7 @@ breaking_changes:
       variable_name: "INSPECT_OUTPUT"
 
     - name: "secrets.yml.enc usage"
+      kind: "deprecation"
       pattern: "secrets\\.yml\\.enc|Rails\\.application\\.secrets"
       exclude: ""
       search_paths:


### PR DESCRIPTION
## Summary

Classifies the new `kind:` field for every pattern in `rails-71-patterns.yml` (Rails 7.0 → 7.1 hop). Part of the cross-version `kind:` rollout tracked in #53; this is sub-issue #63.

## Counts

| kind | count |
|---|---|
| breaking | 1 |
| deprecation | 3 |
| migration | 1 |
| optional | 4 |
| **total** | **9** |

## Per-pattern rationale

| Pattern | kind | Rationale |
|---|---|---|
| cache_classes deprecated | deprecation | Still works in 7.1, emits deprecation warning; replaced by `enable_reloading`. |
| legacy_connection_handling removed | breaking | Explanation: "completely removed... raise an error on boot." |
| preview_path singular deprecated | deprecation | Singular form deprecated in 7.1, plural `preview_paths` is the replacement. |
| Force SSL default changed | optional | New default in production; opt-out via explicit `force_ssl = false`. |
| lib/ autoloading changes | optional | New `autoload_lib` default; opt-in / cleanup of manual paths. |
| SQLite database in db/ directory | optional | Default location moved to `storage/`; existing `db/` paths keep working. |
| Query log tags configuration | optional | New `query_log_tags_format` option; additive. |
| inspect output dependency | migration | AR `inspect` now respects `attributes_for_inspect`; existing tests may need a config tweak but nothing raises or warns by default. |
| secrets.yml.enc usage | deprecation | `Rails.application.secrets` further deprecated in 7.1; migration target is `credentials`. |

## Borderline calls

- **inspect output dependency → migration (not optional / breaking).** No deprecation warning, no boot failure, but apps whose tests assert on AR `inspect` output should migrate to the new `attributes_for_inspect = :all` config to keep behavior. It's a recommended path forward, not a brand-new feature, so `migration` fits better than `optional`.
- **Force SSL default changed / lib autoloading / SQLite location → optional.** All three are new-default changes that the framework happily accepts an explicit override for. None warn, none break, so they are opt-in/opt-out cosmetic-to-medium config changes — `optional`.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-71-patterns.yml` exits 0
- [x] `bin/validate-patterns` (all files) exits 0
- [x] Spot-check: every `- name:` line is followed by a `kind:` line
- [x] Diff is additive only (no other field touched, priority groupings untouched, `dependencies:` untouched)

Refs #53
Closes #63
