### PR TITLE
Classify kind: for rails-72-patterns.yml (#64)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 7.1 → 7.2 upgrade"
 breaking_changes:
   high_priority:
     - name: "Transaction-aware job enqueuing"
+      kind: "migration"
       pattern: "perform_later|deliver_later"
       exclude: ""
       search_paths:
@@ -15,6 +16,7 @@ breaking_changes:
       variable_name: "TRANSACTION_JOBS"
 
     - name: "show_exceptions configuration"
+      kind: "breaking"
       pattern: "show_exceptions\\s*=\\s*(true|false)"
       exclude: ""
       search_paths:
@@ -24,6 +26,7 @@ breaking_changes:
       variable_name: "SHOW_EXCEPTIONS"
 
     - name: "params comparison removed"
+      kind: "breaking"
       pattern: "params\\s*==|==\\s*params"
       exclude: ""
       search_paths:
@@ -34,6 +37,7 @@ breaking_changes:
       variable_name: "PARAMS_COMPARISON"
 
     - name: "ActiveRecord.connection deprecated"
+      kind: "deprecation"
       pattern: "ActiveRecord::Base\\.connection(?!_pool)"
       exclude: "with_connection"
       search_paths:
@@ -44,6 +48,7 @@ breaking_changes:
       variable_name: "AR_CONNECTION"
 
     - name: "Rails.application.secrets removed"
+      kind: "breaking"
       pattern: "Rails\\.application\\.secrets"
       exclude: ""
       search_paths:
@@ -56,6 +61,7 @@ breaking_changes:
 
   medium_priority:
     - name: "serialize syntax change"
+      kind: "breaking"
       pattern: "serialize\\s+:\\w+(?!.*(?:type:|coder:))"
       exclude: ""
       search_paths:
@@ -65,6 +71,7 @@ breaking_changes:
       variable_name: "SERIALIZE_SYNTAX"
 
     - name: "fixture_path deprecated"
+      kind: "deprecation"
       pattern: "fixture_path[^s]"
       exclude: "fixture_paths"
       search_paths:
@@ -76,6 +83,7 @@ breaking_changes:
       variable_name: "FIXTURE_PATH"
 
     - name: "query_constraints deprecated"
+      kind: "deprecation"
       pattern: "query_constraints"
       exclude: ""
       search_paths:
@@ -85,6 +93,7 @@ breaking_changes:
       variable_name: "QUERY_CONSTRAINTS"
 
     - name: "mailer test args syntax"
+      kind: "deprecation"
       pattern: "args:\\s*\\["
       exclude: ""
       search_paths:
@@ -95,6 +104,7 @@ breaking_changes:
       variable_name: "MAILER_TEST_ARGS"
 
     - name: "autoload_lib syntax"
+      kind: "optional"
       pattern: "autoload_lib.*%w\\("
       exclude: ""
       search_paths:
@@ -104,6 +114,7 @@ breaking_changes:
       variable_name: "AUTOLOAD_LIB_SYNTAX"
 
     - name: "Ruby version"
+      kind: "breaking"
       pattern: "ruby.*['\"]3\\.[0-1]"
       exclude: ""
       search_paths:


### PR DESCRIPTION
## Summary

Sub-issue #64 of the issue #53 rollout. Classifies the new `kind:` field for every pattern in `rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml` (11 patterns total — Rails 7.1 → 7.2 hop). `kind:` is placed immediately after `name:`. No other fields touched; `dependencies:` section unchanged.

## Counts

| Kind | Count |
|---|---|
| `breaking` | 5 |
| `deprecation` | 4 |
| `migration` | 1 |
| `optional` | 1 |

## Classification rationale

### HIGH priority

| Variable | Kind | Why |
|---|---|---|
| `TRANSACTION_JOBS` | migration | Default flip gated by `load_defaults 7.2`; old timing persists without it. Recommended path is to test and adopt |
| `SHOW_EXCEPTIONS` | breaking | In-file explanation: "requires symbol values instead of booleans" — booleans no longer accepted |
| `PARAMS_COMPARISON` | breaking | Silent semantic shift — `ActionController::Parameters#==` no longer matches Hash; existing equality checks return `false` |
| `AR_CONNECTION` | deprecation | In-file: "is deprecated in Rails 7.2" |
| `SECRETS_REMOVED` | breaking | In-file: "completely removed in Rails 7.2" |

### MEDIUM priority

| Variable | Kind | Why |
|---|---|---|
| `SERIALIZE_SYNTAX` | breaking | In-file: "requires explicit `type:` or `coder:` parameter" — bare `serialize :col` form no longer accepted |
| `FIXTURE_PATH` | deprecation | In-file: "deprecated in favor of `fixture_paths`" |
| `QUERY_CONSTRAINTS` | deprecation | In-file: "deprecated in Rails 7.2" |
| `MAILER_TEST_ARGS` | deprecation | In-file: "changes `args:` to `params:`" — typical Rails warn-first pattern |
| `AUTOLOAD_LIB_SYNTAX` | optional | Cosmetic style preference (`%w()` → `%w[]`); not enforced by Rails |
| `RUBY_VERSION` | breaking | 7.2 minimum is Ruby 3.1.0; pattern catches Ruby 3.0 which won't boot Rails 7.2 |

## Borderline calls

- **`TRANSACTION_JOBS`** — `migration` rather than `breaking` because the new behavior only activates under `load_defaults "7.2"`. Apps that don't bump load_defaults keep the old (immediate enqueue) timing. Could be argued `breaking` if reviewer treats the load_defaults bump as part of the version upgrade itself, but the pattern of "load_defaults gated" → `migration` is consistent with rails-50 (`BELONGS_TO_REQUIRED`), rails-60 (`BELONGS_TO_REQUIRED`, `CSRF_PROTECTION`), and rails-70 (`FORM_WITH_LOCAL`, `FORGERY_PROTECTION`).
- **`SHOW_EXCEPTIONS`** — `breaking` because the explanation says "requires symbol values". If 7.2 actually emits a deprecation warning for booleans (rather than raising), this should flip to `deprecation`. Going with the explanation's "requires" language.
- **`PARAMS_COMPARISON`** — `breaking` for the silent-shift class. `params == hash` returning `false` where it returned `true` before is a silent correctness break in conditional logic.
- **`SERIALIZE_SYNTAX`** — `breaking` because the explanation says "requires explicit `type:` or `coder:`". If 7.2 emits a deprecation warning for the bare form (with hard removal in 8.0), should flip to `deprecation`. Going with the explanation's "requires" language.
- **`MAILER_TEST_ARGS`** — `deprecation` (default Rails pattern: warn at this hop, remove next). If `args:` raises at 7.2, should flip to `breaking`. The explanation says "changes" which is ambiguous; assuming warn-first.
- **`AUTOLOAD_LIB_SYNTAX`** — `optional` because the change (`%w()` → `%w[]`) is cosmetic. Both forms are valid Ruby and Rails parses both. The fix description says "for consistency", confirming this is style preference rather than a Rails-enforced requirement.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml` passes
- [x] `bin/validate-patterns` (all 12 files) passes — no regression elsewhere
- [x] `kind:` placed immediately after `name:` in every entry
- [x] No other field touched; `dependencies:` section unchanged

## Linked issues

- Refs #53 (parent — schema-cleanup tracking)
- Closes #64
