### PR TITLE
Classify kind: for rails-81-patterns.yml (#66)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-81-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-81-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 8.0 → 8.1 upgrade"
 breaking_changes:
   high_priority:
     - name: "SSL configuration commented"
+      kind: "optional"
       pattern: "#.*force_ssl|#.*assume_ssl"
       exclude: ""
       search_paths:
@@ -13,6 +14,7 @@ breaking_changes:
       variable_name: "SSL_COMMENTED"
 
     - name: "pool to max_connections"
+      kind: "breaking"
       pattern: "pool:"
       exclude: "max_connections"
       search_paths:
@@ -22,6 +24,7 @@ breaking_changes:
       variable_name: "POOL_RENAME"
 
     - name: "bundler-audit required"
+      kind: "optional"
       pattern: "bundler-audit"
       exclude: ""
       search_paths:
@@ -34,6 +37,7 @@ breaking_changes:
 
   medium_priority:
     - name: "Semicolon query separator"
+      kind: "breaking"
       pattern: "param.*;"
       exclude: ""
       search_paths:
@@ -44,6 +48,7 @@ breaking_changes:
       variable_name: "SEMICOLON_SEPARATOR"
 
     - name: "Sidekiq adapter built-in"
+      kind: "breaking"
       pattern: "sidekiq-rails|activejob-sidekiq"
       exclude: ""
       search_paths:
@@ -53,6 +58,7 @@ breaking_changes:
       variable_name: "SIDEKIQ_ADAPTER"
 
     - name: "SuckerPunch adapter"
+      kind: "breaking"
       pattern: "sucker_punch"
       exclude: ""
       search_paths:
@@ -63,6 +69,7 @@ breaking_changes:
       variable_name: "SUCKER_PUNCH"
 
     - name: "Azure storage service"
+      kind: "breaking"
       pattern: "azure_storage|microsoft_azure"
       exclude: ""
       search_paths:
@@ -74,6 +81,7 @@ breaking_changes:
 
   low_priority:
     - name: "MySQL unsigned types"
+      kind: "deprecation"
       pattern: "unsigned:\\s*true"
       exclude: ""
       search_paths:
@@ -83,6 +91,7 @@ breaking_changes:
       variable_name: "MYSQL_UNSIGNED"
 
     - name: "gitignore config keys"
+      kind: "optional"
       pattern: "\\.key$"
       exclude: "/config/"
       search_paths:

--- a/rails-upgrade/detection-scripts/patterns/rails-81-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-81-patterns.yml
@@ -48,13 +48,13 @@ breaking_changes:
       variable_name: "SEMICOLON_SEPARATOR"
 
     - name: "Sidekiq adapter built-in"
-      kind: "breaking"
+      kind: "deprecation"
       pattern: "sidekiq-rails|activejob-sidekiq"
       exclude: ""
       search_paths:
         - "Gemfile"
-      explanation: "Rails 8.1 removes built-in Sidekiq adapter"
-      fix: "Use sidekiq gem directly (6.5+) which includes its own adapter"
+      explanation: "Rails 8.1 deprecates the built-in ActiveJob Sidekiq adapter (NOT removed yet). activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb is still present at 8.1; the activejob/CHANGELOG.md entry says 'Deprecate built-in `sidekiq` adapter. If you're using this adapter, upgrade to `sidekiq` 7.3.3 or later to use the `sidekiq` gem's adapter.' Apps continue to function with a deprecation warning"
+      fix: "Upgrade to sidekiq 7.3.3+ and use the gem's own adapter, which the gem registers when loaded. The Rails-bundled adapter is scheduled for removal in a later version"
       variable_name: "SIDEKIQ_ADAPTER"
 
     - name: "SuckerPunch adapter"

--- a/rails-upgrade/detection-scripts/patterns/rails-81-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-81-patterns.yml
@@ -14,13 +14,13 @@ breaking_changes:
       variable_name: "SSL_COMMENTED"
 
     - name: "pool to max_connections"
-      kind: "breaking"
+      kind: "deprecation"
       pattern: "pool:"
       exclude: "max_connections"
       search_paths:
         - "config/database.yml"
-      explanation: "Rails 8.1 renames 'pool:' to 'max_connections:' in database.yml"
-      fix: "Replace pool: with max_connections: in all database configurations"
+      explanation: "Rails 8.1 renames the database config key from pool: to max_connections:. The old name is preserved as an alias and emits a deprecation warning at runtime; existing apps still boot and connect normally with pool:. activerecord/lib/active_record/database_configurations/hash_config.rb at 8.1 defines `alias :pool :max_connections` followed by `deprecate pool: :max_connections, deprecator: ActiveRecord.deprecator`. Boot only fails when both pool: and max_connections: are set with different values (Ambiguous configuration error)"
+      fix: "Rename pool: to max_connections: in every entry of config/database.yml. Do not set both keys at the same time -- that path raises Ambiguous configuration"
       variable_name: "POOL_RENAME"
 
     - name: "bundler-audit required"

--- a/rails-upgrade/detection-scripts/patterns/rails-81-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-81-patterns.yml
@@ -80,14 +80,14 @@ breaking_changes:
       variable_name: "AZURE_STORAGE"
 
   low_priority:
-    - name: "MySQL unsigned types"
-      kind: "deprecation"
-      pattern: "unsigned:\\s*true"
+    - name: "MySQL unsigned_float / unsigned_decimal short-hand"
+      kind: "breaking"
+      pattern: "\\bunsigned_(float|decimal)\\b"
       exclude: ""
       search_paths:
         - "db/migrate/"
-      explanation: "MySQL unsigned integer types deprecation notice in Rails 8.1"
-      fix: "Use check constraints instead of unsigned integers"
+      explanation: "Rails 8.1 removes the t.unsigned_float and t.unsigned_decimal short-hand column methods that were deprecated in 8.0 (activerecord/CHANGELOG.md: 'Remove deprecated `:unsigned_float` and `:unsigned_decimal` column methods for MySQL.'). Migrations using these short-hands raise NoMethodError. Background: as of MySQL 8.0.17, the UNSIGNED attribute is itself deprecated for FLOAT / DOUBLE / DECIMAL columns at the database level, so Rails no longer ships the convenience methods. Note: the pattern was previously matching `unsigned: true`, which is the column-option form on integer / bigint columns and is unrelated and unaffected"
+      fix: "Replace t.unsigned_float :amount with t.float :amount, unsigned: true (still allowed on integer / bigint via the column option) or, for DECIMAL, use a CHECK constraint on the value range. Audit each migration that used the short-hand"
       variable_name: "MYSQL_UNSIGNED"
 
     - name: "gitignore config keys"


### PR DESCRIPTION
## Summary

Classifies the new `kind:` field for all 9 patterns in `rails-81-patterns.yml` (Rails 8.0 → 8.1). `kind:` is orthogonal to `priority` and tags each entry as `breaking`, `deprecation`, `migration`, or `optional`. Part of #53; closes #66.

## Counts

| kind | count |
|------|-------|
| breaking | 4 |
| deprecation | 2 |
| migration | 0 |
| optional | 3 |
| **total** | **9** |

## Per-pattern rationale

| Pattern (variable_name) | priority | kind | Rationale |
|-------------------------|----------|------|-----------|
| SSL_COMMENTED | HIGH | optional | Template default flip (SSL config commented out, assumes Kamal). Existing config preserved on upgrade; only matters if app re-generates from new template. Opt-in choice. |
| POOL_RENAME | HIGH | **deprecation** | At 8.1, `pool:` is aliased to `max_connections:` with a deprecation warning. `hash_config.rb:84-85`: `alias :pool :max_connections; deprecate pool: :max_connections, deprecator: ActiveRecord.deprecator`. Apps still boot with `pool:`; the "Ambiguous configuration" raise only fires when both keys are set with different values. |
| BUNDLER_AUDIT | HIGH | optional | Adds a security-scanning gem and `bin/brakeman` script. The app boots, bundles, and tests run without it; recommended new tool, not enforced. |
| SEMICOLON_SEPARATOR | MEDIUM | breaking | At 8.1 `actionpack/CHANGELOG.md:111`: "Remove deprecated support for using semicolons as a query string separator." URLs relying on it silently lose params at runtime. |
| SIDEKIQ_ADAPTER | MEDIUM | **deprecation** | At 8.1 `activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb` is still present; CHANGELOG: "Deprecate built-in `sidekiq` adapter. ... upgrade to `sidekiq` 7.3.3 or later to use the `sidekiq` gem's adapter." Apps continue to function with a deprecation warning. |
| SUCKER_PUNCH | MEDIUM | breaking | At 8.1 `sucker_punch_adapter.rb` is removed from the queue_adapters directory. CHANGELOG: "Remove deprecated internal `SuckerPunch` adapter in favor of the adapter included with the `sucker_punch` gem." Apps fail adapter lookup unless the gem is loaded. |
| AZURE_STORAGE | MEDIUM | breaking | At 8.1 `activestorage/lib/active_storage/service/` no longer contains `azure_storage_service.rb`; only `disk`, `gcs`, `mirror`, `s3` remain. Apps using Azure fail to boot the storage subsystem until they switch services. |
| MYSQL_UNSIGNED | LOW | **breaking** | At 8.1 `t.unsigned_float` / `t.unsigned_decimal` short-hand column methods are removed (deprecated at 8.0). CHANGELOG: "Remove deprecated `:unsigned_float` and `:unsigned_decimal` column methods for MySQL." Migrations using the short-hands raise NoMethodError. **Pattern repaired in this PR**: was matching `unsigned: true` (the unrelated column-option form on integer / bigint, still works); now matches `\bunsigned_(float\|decimal)\b`. |
| GITIGNORE_KEYS | LOW | optional | `.gitignore` recommendation change (`*.key` → `/config/*.key`). Cosmetic tooling adjustment. |

## Source-verified flips during code review

Three entries were flipped from the initial classification after verifying against `rails/rails` v8.1.0. Each flip is one commit that bundles the `kind:` change with reconciled `explanation:` and `fix:` text:

- `Flip POOL_RENAME kind to deprecation at 8.1 + reconcile copy` — `pool:` is preserved as a deprecated alias of `max_connections:` at 8.1; apps still boot. Author had `breaking`; flipped to `deprecation`.
- `Flip SIDEKIQ_ADAPTER kind to deprecation at 8.1 + reconcile copy` — adapter file still present; CHANGELOG says "Deprecate", not "Remove". Author had `breaking`; flipped to `deprecation`. Compare with SUCKER_PUNCH in this same file, which is correctly `breaking` because that adapter file *was* deleted at 8.1.
- `Flip MYSQL_UNSIGNED kind to breaking at 8.1 + repair pattern + reconcile copy` — the deprecated short-hand methods (`unsigned_float`, `unsigned_decimal`) are *removed* at 8.1, not deprecated. Pattern previously matched `unsigned: true` (unrelated and unaffected); repaired to `\bunsigned_(float\|decimal)\b`. Author had `deprecation`; flipped to `breaking` and pattern fixed.

## Borderline calls

- **SSL_COMMENTED (optional vs breaking):** Header places this HIGH because misconfigured SSL has production impact, but it is a template default change — existing apps keep their `force_ssl = true` line. The pattern only matches when SSL config is already commented out, so the fix is an opt-in choice ("uncomment if not on Kamal"). Classified `optional` to reflect that nothing breaks at boot. Priority remains HIGH (production-impact awareness).
- **BUNDLER_AUDIT (optional vs migration):** Could be `migration`, but the rollout convention has reserved `migration` for `load_defaults`-gated default flips. bundler-audit is a tooling addition, so `optional` is the better fit.

## Out of scope (sibling-issue material)

The file misses several 8.1 changes outside of what's currently flagged. Same scoping bias as #85 (5.1) and #86 (8.0). A standalone sibling issue tracks the gap and proposes the missing entries; not addressed in this PR.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-81-patterns.yml` exits 0
- [x] `bin/validate-patterns` (all files) exits 0
- [x] `kind:` placed immediately after `name:` in every entry
- [x] No fields, priority groupings, or `dependencies:` section touched outside the three flipped entries
- [x] `breaking_changes:` top-level key not renamed
- [x] Three flipped entries source-verified against `rails/rails` v8.1.0; commits include file:line references and CHANGELOG quotes

Refs #53
Closes #66
