### PR TITLE
Classify kind: for rails-80-patterns.yml (#65)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml
@@ -4,6 +4,7 @@ description: "Breaking change patterns for Rails 7.2 → 8.0 upgrade"
 breaking_changes:
   high_priority:
     - name: "Sprockets usage"
+      kind: "migration"
       pattern: "sprockets|Sprockets"
       exclude: "propshaft"
       search_paths:
@@ -15,6 +16,7 @@ breaking_changes:
       variable_name: "SPROCKETS"
 
     - name: "Asset pipeline configuration"
+      kind: "migration"
       pattern: "config\\.assets\\."
       exclude: ""
       search_paths:
@@ -25,6 +27,7 @@ breaking_changes:
       variable_name: "ASSET_CONFIG"
 
     - name: "javascript_include_tag (missing importmap)"
+      kind: "migration"
       pattern: "javascript_include_tag"
       exclude: "importmap"
       search_paths:
@@ -34,6 +37,7 @@ breaking_changes:
       variable_name: "JS_INCLUDE"
 
     - name: "assume_ssl configuration"
+      kind: "optional"
       pattern: "force_ssl\\s*="
       exclude: "assume_ssl"
       search_paths:
@@ -43,6 +47,7 @@ breaking_changes:
       variable_name: "ASSUME_SSL"
 
     - name: "sqlite3_deprecated_warning"
+      kind: "breaking"
       pattern: "sqlite3_deprecated_warning"
       exclude: ""
       search_paths:
@@ -53,6 +58,7 @@ breaking_changes:
 
   medium_priority:
     - name: "Redis cache store"
+      kind: "optional"
       pattern: "redis_cache_store|:redis_store"
       exclude: "solid_cache"
       search_paths:
@@ -62,6 +68,7 @@ breaking_changes:
       variable_name: "REDIS_CACHE"
 
     - name: "Sidekiq/Redis queue"
+      kind: "optional"
       pattern: "sidekiq|:sidekiq|:async"
       exclude: "solid_queue"
       search_paths:
@@ -72,6 +79,7 @@ breaking_changes:
       variable_name: "SIDEKIQ_QUEUE"
 
     - name: "ActionCable Redis adapter"
+      kind: "optional"
       pattern: "adapter:\\s*redis|:redis"
       exclude: "solid"
       search_paths:
@@ -81,6 +89,7 @@ breaking_changes:
       variable_name: "CABLE_REDIS"
 
     - name: "Kamal deployment"
+      kind: "optional"
       pattern: "kamal|deploy\\.yml"
       exclude: ""
       search_paths:
@@ -91,6 +100,7 @@ breaking_changes:
       variable_name: "KAMAL_DEPLOY"
 
     - name: "Docker/Thruster"
+      kind: "optional"
       pattern: "thruster"
       exclude: ""
       search_paths:
@@ -101,6 +111,7 @@ breaking_changes:
       variable_name: "THRUSTER"
 
     - name: "Database pool configuration"
+      kind: "migration"
       pattern: "pool:\\s*\\d+"
       exclude: "max_connections"
       search_paths:


### PR DESCRIPTION
## Summary

Sub-issue #65 of the issue #53 rollout. Classifies the new `kind:` field for every pattern in `rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml` (11 patterns total — Rails 7.2 → 8.0 hop). `kind:` is placed immediately after `name:`. No other fields touched; `dependencies:` section unchanged.

The 7.2 → 8.0 hop is heavy on **new defaults** (Propshaft, Solid Cache / Queue / Cable, Kamal, Thruster, Import Maps) but old gems keep working. That's why the kind distribution skews `optional` (new opt-in) and `migration` (recommended path) rather than `breaking` / `deprecation`. Only one entry is hard-`breaking` (a removed config option).

## Counts

| Kind | Count |
|---|---|
| `breaking` | 1 |
| `deprecation` | 0 |
| `migration` | 4 |
| `optional` | 6 |

## Classification rationale

### HIGH priority

| Variable | Kind | Why |
|---|---|---|
| `SPROCKETS` | migration | Sprockets still works with explicit config; Propshaft is the recommended path forward |
| `ASSET_CONFIG` | migration | Vague FILE MARKER — "review and update for Propshaft compatibility" |
| `JS_INCLUDE` | migration | `javascript_include_tag` still works; Import Maps is the recommended path |
| `ASSUME_SSL` | optional | New config option for SSL handling behind proxies; `force_ssl` alone still works without it |
| `SQLITE3_WARNING` | breaking | In-file: "option removed in Rails 8.0" |

### MEDIUM priority

| Variable | Kind | Why |
|---|---|---|
| `REDIS_CACHE` | optional | In-file: "Solid Cache - Redis is optional" — both work |
| `SIDEKIQ_QUEUE` | optional | In-file: "Solid Queue - Sidekiq still works" — both work |
| `CABLE_REDIS` | optional | In-file: "Solid Cable - Redis adapter still works" — both work |
| `KAMAL_DEPLOY` | optional | New bundled deployment tool; ignorable for non-Kamal deploys |
| `THRUSTER` | optional | Opt-in HTTP/2 + static-asset gem; "Add if using Docker" |
| `DB_POOL` | migration | `database.yml` restructure recommended for Solid gems' multi-DB layout |

## Borderline calls

- **`SPROCKETS` / `ASSET_CONFIG` / `JS_INCLUDE`** — all `migration`. Could plausibly be `optional` (Sprockets still works fine; many apps will not migrate). Going with `migration` because Rails 8.0 ships Propshaft as the default for new apps and the trajectory is to phase out Sprockets — adopting now avoids a forced migration later. If reviewer thinks "old asset pipeline still works" carries more weight than "Rails is moving in this direction", these flip to `optional`.
- **`ASSUME_SSL`** — `optional`, not `migration`. The new config is purely additive; nothing changes for apps without proxies. Apps behind proxies SHOULD adopt, but the absence isn't a problem.
- **`DB_POOL`** — `migration`, not `optional`. The restructure is required if the app adopts Solid gems (which is the 8.0 default). If staying on Sidekiq/Redis, the old layout works.
- **No `deprecation` entries** — Rails 8.0 introduced new defaults without deprecating any of the alternatives in this set. Surprising at first glance, but consistent with the in-file `explanation` language ("still works", "optional", "default to") across every entry.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml` passes
- [x] `bin/validate-patterns` (all 12 files) passes — no regression elsewhere
- [x] `kind:` placed immediately after `name:` in every entry
- [x] No other field touched; `dependencies:` section unchanged

## Linked issues

- Refs #53 (parent — schema-cleanup tracking)
- Closes #65
