### PR TITLE
Require kind: field on every detection pattern entry (#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file captures project-specific conventions Claude should follow when workin
 - `bin/validate-patterns` validates every detection pattern YAML file under `rails-upgrade/detection-scripts/patterns/`. Run it before committing any change to a pattern file. Pure-stdlib Ruby, no Bundler or Gemfile required.
   - `bin/validate-patterns` validates every file
   - `bin/validate-patterns path/to/file.yml` validates one or more specific files
-  - Checks: YAML parses, required top-level keys present, the seven required pattern keys present on each entry, every `pattern` / `exclude` regex compiles, and any `kind:` value (optional during the issue #53 rollout) is one of the allowed enum values
+  - Checks: YAML parses, required top-level keys present, the eight required pattern keys present on each entry, every `pattern` / `exclude` regex compiles, and the `kind:` value is one of the allowed enum values (`breaking`, `deprecation`, `migration`, `optional`)
   - Exits 0 on success, 1 on any failure with a per-file error report
 
 ## Version guides (`rails-upgrade/version-guides/*.md`)
@@ -22,7 +22,7 @@ This file captures project-specific conventions Claude should follow when workin
 
 - File naming: `rails-{VERSION}-patterns.yml` where `{VERSION}` is the major+minor without a dot (e.g., `rails-42-patterns.yml` for Rails 4.2).
 - Organize patterns under `high_priority`, `medium_priority`, and `low_priority`.
-- Each pattern needs: `name`, `pattern` (regex), `exclude` (regex, empty string if none), `search_paths`, `explanation`, `fix`, `variable_name`. New entries should also set `kind:` (see "Assigning kind" below); the field is optional during the issue #53 rollout and becomes required once every pattern file has been classified.
+- Each pattern needs: `name`, `kind` (one of `breaking` / `deprecation` / `migration` / `optional` — see "Assigning kind" below), `pattern` (regex), `exclude` (regex, empty string if none), `search_paths`, `explanation`, `fix`, `variable_name`. Place `kind:` immediately after `name:` for visual scannability.
 - Include a `dependencies` section for any bridge/compatibility gems mentioned in the guide.
 - **Required before committing any change to a detection pattern file:** run `bin/validate-patterns` (or `bin/validate-patterns path/to/file.yml` for the file you touched). Do not commit a pattern change without a clean run; broken YAML or schema drift in this directory breaks the skill at runtime. See the `## Repository tooling` section above for what the script checks.
 

--- a/bin/validate-patterns
+++ b/bin/validate-patterns
@@ -13,7 +13,7 @@ require "yaml"
 
 PATTERNS_DIR = File.expand_path("../rails-upgrade/detection-scripts/patterns", __dir__)
 TOP_LEVEL_KEYS = %w[version description breaking_changes].freeze
-PATTERN_KEYS = %w[name pattern exclude search_paths explanation fix variable_name].freeze
+PATTERN_KEYS = %w[name kind pattern exclude search_paths explanation fix variable_name].freeze
 PRIORITY_KEYS = %w[high_priority medium_priority low_priority].freeze
 KIND_VALUES = %w[breaking deprecation migration optional].freeze
 

--- a/rails-upgrade/CHANGELOG.md
+++ b/rails-upgrade/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - `bin/validate-patterns` now accepts an optional `kind:` field on every pattern entry. Allowed values: `breaking`, `deprecation`, `migration`, `optional`. The validator rejects unknown values to guard against typos. The field is optional during the issue #53 rollout and becomes required once every pattern file has been classified. Documented the rubric in `CLAUDE.md` under "Assigning `kind:`".
+- `bin/validate-patterns` now **requires** the `kind:` field on every pattern entry (issue #53 rollout, sub-issue #67). All 12 pattern files have been classified across the preceding 12 sub-issues. Updated `CLAUDE.md` to list `kind:` among the required per-pattern fields and to remove the rollout caveat.
 
 ## v3.3.0, 28 April 2026
 - Added `upgrade-cleanup` companion plugin for finishing a Rails upgrade campaign. Removes dual-boot scaffolding, drops `NextRails.next?` / `NextRails.current?` branches, retires stale monkey-patches and version-conditional code, and aligns CI matrix / Dockerfile / Ruby pin to the new version baseline. Lives as a sibling plugin in this repo (`upgrade-cleanup/.claude-plugin/plugin.json` + `upgrade-cleanup/upgrade-cleanup/SKILL.md` + `upgrade-cleanup/upgrade-cleanup/workflows/upgrade-cleanup-workflow.md`). `load_defaults` alignment and deprecation triage stay with the rails-upgrade skill, cleanup deliberately does not duplicate them. Based on FastRuby.io's "Finishing an Upgrade" methodology. (Closes #1)


### PR DESCRIPTION
## Summary

Sub-issue #67 of the issue #53 rollout. Tightens `bin/validate-patterns` to **require** the `kind:` field on every pattern entry. All 12 pattern files were classified across sub-issues #55 through #66 (189 entries total), so this is the final tightening step before the `breaking_changes:` → `upgrade_findings:` rename (#68) and the detection-output grouping (#69).

The whole functional change is one word: adding `kind` to the `PATTERN_KEYS` constant in the validator.

## Changes

- **`bin/validate-patterns`** — `PATTERN_KEYS` gains `"kind"`. Missing `kind:` now fires the existing "missing key" error path. The enum check (added in #54) continues to fire for invalid values.
- **`CLAUDE.md`** — bumped "seven required pattern keys" → "eight"; listed `kind` inline in the per-pattern field bullet with a placement note ("immediately after `name:`"); removed the rollout caveat.
- **`rails-upgrade/CHANGELOG.md`** — `Unreleased` entry.

## Test plan

- [x] `bin/validate-patterns` passes on all 12 existing pattern files (every entry has `kind:` set after #55–#66 merged)
- [x] Synthetic fixture missing `kind:` fails with `high_priority[0] (Test entry): missing key: kind`, exit 1
- [x] No double-error path when `kind:` is absent (enum check only fires when `kind:` is present)

## Linked issues

- Refs #53 (parent — schema-cleanup tracking)
- Closes #67
- Unblocks #68 (rename `breaking_changes:` → `upgrade_findings:`) and #69 (surface `kind:` in detection output)
- Test-coverage gap for the rejection paths is tracked separately in #71

## Out of scope

- Adding automated tests for the rejection paths (tracked in #71)
- The top-level rename to `upgrade_findings:` (#68)
- Detection-output grouping by `kind:` (#69)
