### PR TITLE
Add missing 5.1 deprecation entries to rails-51-patterns.yml

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
@@ -144,6 +144,72 @@ upgrade_findings:
       fix: "Use symbol keys: `Rails.application.secrets.smtp_settings[:address]` instead of `[\"address\"]`"
       variable_name: "SECRETS_METHOD_ACCESSOR_STRING_KEYS"
 
+    - name: "ActionDispatch::ParamsParser::ParseError"
+      kind: "deprecation"
+      pattern: "ActionDispatch::ParamsParser::ParseError"
+      exclude: ""
+      search_paths:
+        - "app/controllers/"
+        - "app/middleware/"
+        - "lib/"
+      explanation: "Rails 5.1 deprecates ActionDispatch::ParamsParser::ParseError in favor of ActionDispatch::Http::Parameters::ParseError. The old constant is preserved at 5.1 with a deprecation warning when referenced; removal scheduled for a later Rails version. Apps usually hit this in rescue handlers around malformed JSON / params"
+      fix: "Replace ActionDispatch::ParamsParser::ParseError with ActionDispatch::Http::Parameters::ParseError in rescue clauses"
+      variable_name: "PARAMS_PARSER_ERROR"
+
+    - name: "set_callback / skip_callback string :if / :unless"
+      kind: "deprecation"
+      pattern: "(set_callback|skip_callback)\\b[^\\n]*\\b(if|unless):\\s*['\"]"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 5.1 deprecates passing a string to :if / :unless options on set_callback and skip_callback. Use a symbol (method name) or a lambda. NOISY REGEX: matches set_callback / skip_callback call sites with inline string conditions; most projects do not call these directly (they use the higher-level before_*, after_* DSL covered by FILTER_STRING_CONDITIONS in this file). For projects that do call them, inspect each match"
+      fix: "Replace the string with a symbol: `set_callback :save, :before, :method_name, if: :should_run?` instead of `if: 'should_run?'`. For inline expressions use a lambda: `if: -> { ... }`"
+      variable_name: "SET_CALLBACK_STRING_CONDITIONS"
+
+    - name: "lock! on dirty AR record"
+      kind: "deprecation"
+      pattern: "\\.lock!(?=\\(|\\s|$)"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 5.1 deprecates calling #lock! on an ActiveRecord record with unsaved changes. activerecord/lib/active_record/locking/pessimistic.rb at 5.1 emits ActiveSupport::Deprecation.warn 'Locking a record with unpersisted changes is deprecated and will raise an exception in Rails 5.2'. NOISY REGEX: matches every .lock! call site; most are correct usage on persisted records with no in-memory edits. Audit each match. The 5.2 hop turns this into a RuntimeError (see rails-52-patterns.yml LOCK_BANG_UNPERSISTED)"
+      fix: "Save (or reload) before locking: record.save; record.lock!. If you intended to lock and then mutate, the correct order is record.lock! followed by the assignment + save"
+      variable_name: "LOCK_BANG_DEPRECATION"
+
+  low_priority:
+    - name: "raise_on_unfiltered_parameters config"
+      kind: "deprecation"
+      pattern: "raise_on_unfiltered_parameters"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 5.1 deprecates config.action_controller.raise_on_unfiltered_parameters. The setting has had no effect since 5.1; existing config lines emit a deprecation warning at boot"
+      fix: "Remove the line entirely from config/application.rb or environment configs"
+      variable_name: "RAISE_ON_UNFILTERED_PARAMS"
+
+    - name: "halt_callback_chains_on_return_false"
+      kind: "deprecation"
+      pattern: "halt_callback_chains_on_return_false"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 5.1 deprecates ActiveSupport.halt_callback_chains_on_return_false. The underlying `return false` halt mechanism was already removed at 5.0; the 5.1 config setter is a no-op deprecated shim. Removed entirely at 5.2 (see rails-52-patterns.yml HALT_CALLBACK_CHAINS_ON_RETURN_FALSE for the breaking entry)"
+      fix: "Remove the assignment from config/application.rb / initializers. Code that relied on `return false` to halt callbacks should already be using `throw :abort` after the 4.2 → 5.0 hop"
+      variable_name: "HALT_CALLBACK_CHAINS_DEPRECATION"
+
+    - name: "Defining quoted_id"
+      kind: "deprecation"
+      pattern: "def\\s+quoted_id\\b"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+        - "lib/"
+      explanation: "Rails 5.1 deprecates overriding ActiveRecord's #quoted_id. The hook is preserved at 5.1 with a deprecation warning when the user-defined method fires during quoting. Removed at 5.2 — at the 5.2 hop, defining the method no longer raises but is silently dead (see rails-52-patterns.yml QUOTED_ID_METHOD)"
+      fix: "Migrate the logic to a custom ActiveModel::Type (define #serialize / #cast) or accept the model's default quoting behavior"
+      variable_name: "QUOTED_ID_DEPRECATION"
+
 dependencies:
   webpacker:
     check: false

--- a/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml
@@ -158,7 +158,7 @@ upgrade_findings:
 
     - name: "set_callback / skip_callback string :if / :unless"
       kind: "deprecation"
-      pattern: "(set_callback|skip_callback)\\b[^\\n]*\\b(if|unless):\\s*['\"]"
+      pattern: "(set_callback|skip_callback)\\b[^\\n]*\\b(?:(?:if|unless):|:(?:if|unless)\\s*=>)\\s*['\"]"
       exclude: ""
       search_paths:
         - "app/"


### PR DESCRIPTION
## Summary

Closes #85.

Adds six deprecation entries to `rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml` that were introduced at Rails 5.1 but were not in the file. The original file was scoped to 5.1 *removals* (e.g. `*_filter`, `redirect_to :back`, `render :text/:nothing`, `RELATION_UNIQ`, `USE_TRANSACTIONAL_FIXTURES`). This PR fills in the deprecation-warning surface introduced at the same hop, so an app upgrading 5.0 → 5.1 gets early-warning hooks instead of being surprised at 5.2 when those deprecations turn into removals.

Each entry's deprecation site was verified against `rails/rails` v5.1.0 CHANGELOGs and the corresponding `ActiveSupport::Deprecation.warn` call in source.

## Source citations (rails/rails v5.1.0)

| variable_name | CHANGELOG entry text | Source link |
|---|---|---|
| `PARAMS_PARSER_ERROR` | "Deprecate `ActionDispatch::ParamsParser::ParseError` in favor of `ActionDispatch::Http::Parameters::ParseError`." | [actionpack/CHANGELOG.md#L258](https://github.com/rails/rails/blob/v5.1.0/actionpack/CHANGELOG.md#L258) |
| `SET_CALLBACK_STRING_CONDITIONS` | "Deprecate passing string to `:if` and `:unless` conditional options on `set_callback` and `skip_callback`." | [activesupport/CHANGELOG.md#L255-L256](https://github.com/rails/rails/blob/v5.1.0/activesupport/CHANGELOG.md#L255-L256) |
| `LOCK_BANG_DEPRECATION` | "Deprecate locking records with unpersisted changes." | [activerecord/CHANGELOG.md#L180](https://github.com/rails/rails/blob/v5.1.0/activerecord/CHANGELOG.md#L180) · [pessimistic.rb#L62-L70 (warn site)](https://github.com/rails/rails/blob/v5.1.0/activerecord/lib/active_record/locking/pessimistic.rb#L62-L70) |
| `RAISE_ON_UNFILTERED_PARAMS` | "Deprecate `config.action_controller.raise_on_unfiltered_parameters`. This option has no effect in Rails 5.1." | [actionpack/CHANGELOG.md#L13](https://github.com/rails/rails/blob/v5.1.0/actionpack/CHANGELOG.md#L13) |
| `HALT_CALLBACK_CHAINS_DEPRECATION` | "Deprecate `ActiveSupport.halt_callback_chains_on_return_false`." | [activesupport/CHANGELOG.md#L247](https://github.com/rails/rails/blob/v5.1.0/activesupport/CHANGELOG.md#L247) · [active_support.rb#L82-L94 (warn site)](https://github.com/rails/rails/blob/v5.1.0/activesupport/lib/active_support.rb#L82-L94) |
| `QUOTED_ID_DEPRECATION` | "Deprecate using `#quoted_id` in quoting." | [activerecord/CHANGELOG.md#L103](https://github.com/rails/rails/blob/v5.1.0/activerecord/CHANGELOG.md#L103) · [quoting.rb#L11-L16 (warn site)](https://github.com/rails/rails/blob/v5.1.0/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L11-L16) |

## Entries added

### Medium priority (typical-app surface, deprecation warns at runtime)

| variable_name | pattern target | rationale |
|---|---|---|
| `PARAMS_PARSER_ERROR` | `ActionDispatch::ParamsParser::ParseError` | Apps usually hit this in rescue handlers around malformed JSON / params. |
| `SET_CALLBACK_STRING_CONDITIONS` | `set_callback` / `skip_callback` with string `:if` / `:unless` | Lower-level counterpart of the existing `FILTER_STRING_CONDITIONS` entry which covers the higher-level controller filter DSL. |
| `LOCK_BANG_DEPRECATION` | `.lock!` on a dirty AR record | `pessimistic.rb` at 5.1 emits "Locking a record with unpersisted changes is deprecated and will raise an exception in Rails 5.2". Cross-references `LOCK_BANG_UNPERSISTED` in `rails-52-patterns.yml` (where it raises). |

### Low priority (config-only or rarely-defined hook)

| variable_name | pattern target | rationale |
|---|---|---|
| `RAISE_ON_UNFILTERED_PARAMS` | `raise_on_unfiltered_parameters` | `config.action_controller.raise_on_unfiltered_parameters` is a no-op deprecated shim at 5.1. |
| `HALT_CALLBACK_CHAINS_DEPRECATION` | `halt_callback_chains_on_return_false` | 5.1 deprecation site for `ActiveSupport.halt_callback_chains_on_return_false`. Cross-references `HALT_CALLBACK_CHAINS_ON_RETURN_FALSE` in `rails-52-patterns.yml` (where it is removed). |
| `QUOTED_ID_DEPRECATION` | `def quoted_id` | 5.1 deprecation for defining `#quoted_id` on a model. Cross-references `QUOTED_ID_METHOD` in `rails-52-patterns.yml` (where the method is silently dead). |

## Out of scope

Per the issue's "typical-app surface" scope, this PR skips gem-author / Rails-internal entries: `Migrator.schema_migrations_table_name`, `supports_migrations?` / `supports_primary_key?`, `ColumnDumper#migration_keys`, `:default` arg to `index_name_exists?`. Typical apps reach those only via monkey-patches; the noise/value ratio doesn't justify a regex.

## Test plan

- [x] All six new entries placed under existing `medium_priority` and `low_priority` sections (the file did not previously have a `low_priority` section; one was added).
- [x] `kind:` placed immediately after `name:` on every new entry, consistent with the surrounding file.
- [x] All new patterns compile (Ruby `Regexp.new`).
- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-51-patterns.yml` passes.
- [x] `bin/validate-patterns` (all files) passes.
- [x] No existing entry, regex, priority grouping, or `dependencies:` block was modified.

## Cross-references

- `LOCK_BANG_UNPERSISTED` in `rails-52-patterns.yml` — 5.2 hop where the deprecation becomes a `RuntimeError`.
- `HALT_CALLBACK_CHAINS_ON_RETURN_FALSE` in `rails-52-patterns.yml` — 5.2 hop where the config setter is removed entirely.
- `QUOTED_ID_METHOD` in `rails-52-patterns.yml` — 5.2 hop where the hook is removed and user methods are silently dead.

Refs #53 (overall `kind:` rollout)
