### PR TITLE
Add missing 8.0 breaking + deprecation entries to rails-80-patterns.yml

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml
@@ -3,6 +3,27 @@ description: "Breaking change patterns for Rails 7.2 → 8.0 upgrade"
 
 upgrade_findings:
   high_priority:
+    - name: "Ruby version requirement"
+      kind: "breaking"
+      pattern: "ruby.*['\"](2\\.|3\\.[01])"
+      exclude: ""
+      search_paths:
+        - "Gemfile"
+        - ".ruby-version"
+      explanation: "Rails 8.0 requires Ruby 3.2.0 or newer (rails.gemspec: required_ruby_version = '>= 3.2.0'). Apps on Ruby 3.1 or older fail to bundle"
+      fix: "Upgrade Ruby to 3.2.0+ before bumping Rails. Update Gemfile and .ruby-version, then `bundle update rails`"
+      variable_name: "RUBY_VERSION"
+
+    - name: "enum with keyword-arguments form"
+      kind: "breaking"
+      pattern: "^\\s*enum\\s+\\w+:\\s*"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 8.0 removes the keyword-arguments form of enum (`enum status: { ... }, _prefix: true`). The 7.0 / 7.1 hash form (`enum :status, { ... }, prefix: true`) is now the only supported syntax. activerecord/CHANGELOG.md: 'Remove deprecated support for defining `enum` with keyword arguments.' Models still using the old form raise ArgumentError on class load — the app fails to boot"
+      fix: "Convert to the explicit form: `enum :status, { active: 0, archived: 1 }, prefix: true`. Mechanical migration; no runtime behavior change once converted"
+      variable_name: "ENUM_KWARGS"
+
     - name: "Sprockets usage"
       kind: "migration"
       pattern: "sprockets|Sprockets"
@@ -119,6 +140,93 @@ upgrade_findings:
       explanation: "Rails 8.0 restructures database.yml for Solid gems"
       fix: "Review database.yml structure for multi-database support"
       variable_name: "DB_POOL"
+
+    - name: "ENV[\"SCHEMA_CACHE\"] usage"
+      kind: "breaking"
+      pattern: "ENV\\[['\"]SCHEMA_CACHE['\"]\\]"
+      exclude: ""
+      search_paths:
+        - "config/"
+        - "lib/"
+        - "bin/"
+      explanation: "Rails 8.0 removes deprecated support for setting ENV['SCHEMA_CACHE']. activerecord/CHANGELOG.md: 'Remove deprecated support to setting ENV[\"SCHEMA_CACHE\"].' Apps reading or assigning this env var lose the schema-cache control hook; rake tasks or initializers that depended on it stop influencing schema cache behavior"
+      fix: "Use the schema_cache_path / cache_dump_filename API directly, or rely on the new ActiveRecord::Base.schema_cache_ignored_tables / connection_pool.schema_reflection knobs depending on the use case"
+      variable_name: "ENV_SCHEMA_CACHE"
+
+    - name: "Routes drawn with multiple paths"
+      kind: "deprecation"
+      pattern: "^\\s*(get|post|put|patch|delete|match)\\s+\\["
+      exclude: ""
+      search_paths:
+        - "config/routes.rb"
+      explanation: "Rails 8.0 deprecates drawing a single route action with an array of paths (e.g. `get ['/old1', '/old2'], to: 'foo#bar'`). actionpack/CHANGELOG.md: 'Deprecate drawing routes with multiple paths to make routing faster. You may use `with_options` or a loop to make drawing multiple paths easier.' Removed at 8.1"
+      fix: "Replace the array with a `with_options` block or an explicit loop: `['/old1','/old2'].each { |p| get p, to: 'foo#bar' }`. The new shape is faster at boot time"
+      variable_name: "ROUTES_MULTIPLE_PATHS"
+
+  low_priority:
+    - name: "warn_on_records_fetched_greater_than config"
+      kind: "breaking"
+      pattern: "warn_on_records_fetched_greater_than"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 8.0 removes config.active_record.warn_on_records_fetched_greater_than. activerecord/CHANGELOG.md: 'Remove deprecated `config.active_record.warn_on_records_fetched_greater_than`.' Existing config lines raise NoMethodError at boot"
+      fix: "Remove the line entirely. For per-query large-result-set warnings, use `find_each` / `in_batches` and standard application-level instrumentation"
+      variable_name: "WARN_ON_RECORDS_FETCHED"
+
+    - name: "allow_deprecated_singular_associations_name config"
+      kind: "breaking"
+      pattern: "allow_deprecated_singular_associations_name"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 8.0 removes config.active_record.allow_deprecated_singular_associations_name. activerecord/CHANGELOG.md: 'Remove deprecated `config.active_record.allow_deprecated_singular_associations_name`.' Existing config lines raise NoMethodError at boot"
+      fix: "Remove the line entirely and audit any associations that relied on the deprecated singular name resolution"
+      variable_name: "ALLOW_DEPRECATED_SINGULAR_ASSOCIATIONS_NAME"
+
+    - name: "commit_transaction_on_non_local_return config"
+      kind: "breaking"
+      pattern: "commit_transaction_on_non_local_return"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "Rails 8.0 removes config.active_record.commit_transaction_on_non_local_return. activerecord/CHANGELOG.md: 'Remove deprecated `config.active_record.commit_transaction_on_non_local_return`.' Existing config lines raise NoMethodError at boot"
+      fix: "Remove the line entirely; the post-deprecation behavior (rollback on non-local return) is now the only behavior"
+      variable_name: "COMMIT_TRANSACTION_ON_NON_LOCAL_RETURN"
+
+    - name: "unsigned_float / unsigned_decimal in migrations"
+      kind: "deprecation"
+      pattern: "\\bunsigned_(float|decimal)\\b"
+      exclude: ""
+      search_paths:
+        - "db/migrate/"
+      explanation: "Rails 8.0 deprecates the `t.unsigned_float` and `t.unsigned_decimal` short-hand column methods. activerecord/CHANGELOG.md: 'Deprecate `unsigned_float` and `unsigned_decimal` short-hand column methods.' Background: as of MySQL 8.0.17 the UNSIGNED attribute is itself deprecated for FLOAT / DOUBLE / DECIMAL columns at the database level. Removed at 8.1 (see rails-81-patterns.yml MYSQL_UNSIGNED)"
+      fix: "Replace `t.unsigned_float :amount` with `t.float :amount, unsigned: true` (column-option form on integer / bigint stays unaffected). For DECIMAL, prefer a CHECK constraint on the value range"
+      variable_name: "UNSIGNED_FLOAT_DECIMAL"
+
+    - name: "Benchmark.ms"
+      kind: "deprecation"
+      pattern: "\\bBenchmark\\.ms\\b"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Rails 8.0 deprecates the `Benchmark.ms` core extension. activesupport/CHANGELOG.md: 'Deprecate `Benchmark.ms` core extension. The benchmark gem will become bundled in Ruby 3.5.' Removed at 8.1"
+      fix: "Add `gem 'benchmark'` to the Gemfile (will be bundled with Ruby 3.5; explicit until then) and require 'benchmark' wherever `Benchmark.ms` is used. Or replace with `Process.clock_gettime(Process::CLOCK_MONOTONIC)` deltas for hot paths"
+      variable_name: "BENCHMARK_MS"
+
+    - name: "rake stats"
+      kind: "deprecation"
+      pattern: "\\brake\\s+stats\\b"
+      exclude: ""
+      search_paths:
+        - "bin/"
+        - ".github/"
+        - ".circleci/"
+        - "Rakefile"
+      explanation: "Rails 8.0 deprecates `bin/rake stats` in favor of `bin/rails stats`. railties/CHANGELOG.md: 'Deprecate `bin/rake stats` in favor of `bin/rails stats`.' The rake task continues to work at 8.0 with a deprecation warning"
+      fix: "Replace `rake stats` with `rails stats` in CI configs, scripts, and developer docs"
+      variable_name: "RAKE_STATS"
 
 dependencies:
   propshaft:


### PR DESCRIPTION
## Summary

Closes #86.

Adds ten entries to `rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml` that were not previously in the file. The original file was scoped to the 8.0 migration story (Sprockets → Propshaft, the Solid suite, Kamal, Thruster, asset pipeline). This PR fills in the **removal-cycle** and **new-deprecation** surfaces that the same hop also ships, plus the Ruby-version floor.

Each entry's removal / deprecation site was verified against `rails/rails` v8.0.0.

## Source citations (rails/rails v8.0.0)

| variable_name | CHANGELOG entry text | Source link |
|---|---|---|
| `RUBY_VERSION` | `s.required_ruby_version = ">= 3.2.0"` | [rails.gemspec#L12](https://github.com/rails/rails/blob/v8.0.0/rails.gemspec#L12) |
| `ENUM_KWARGS` | "Remove deprecated support for defining `enum` with keyword arguments." | [activerecord/CHANGELOG.md#L64](https://github.com/rails/rails/blob/v8.0.0/activerecord/CHANGELOG.md#L64) |
| `ENV_SCHEMA_CACHE` | "Remove deprecated support to setting `ENV[\"SCHEMA_CACHE\"]`." | [activerecord/CHANGELOG.md#L44](https://github.com/rails/rails/blob/v8.0.0/activerecord/CHANGELOG.md#L44) |
| `ROUTES_MULTIPLE_PATHS` | "Deprecate drawing routes with multiple paths to make routing faster. You may use `with_options` or a loop to make drawing multiple paths easier." | [actionpack/CHANGELOG.md#L131](https://github.com/rails/rails/blob/v8.0.0/actionpack/CHANGELOG.md#L131) |
| `WARN_ON_RECORDS_FETCHED` | "Remove deprecated `config.active_record.warn_on_records_fetched_greater_than`." | [activerecord/CHANGELOG.md#L60](https://github.com/rails/rails/blob/v8.0.0/activerecord/CHANGELOG.md#L60) |
| `ALLOW_DEPRECATED_SINGULAR_ASSOCIATIONS_NAME` | "Remove deprecated `config.active_record.allow_deprecated_singular_associations_name`." | [activerecord/CHANGELOG.md#L72](https://github.com/rails/rails/blob/v8.0.0/activerecord/CHANGELOG.md#L72) |
| `COMMIT_TRANSACTION_ON_NON_LOCAL_RETURN` | "Remove deprecated `config.active_record.commit_transaction_on_non_local_return`." | [activerecord/CHANGELOG.md#L76](https://github.com/rails/rails/blob/v8.0.0/activerecord/CHANGELOG.md#L76) |
| `UNSIGNED_FLOAT_DECIMAL` | "Deprecate `unsigned_float` and `unsigned_decimal` short-hand column methods. As of MySQL 8.0.17, the UNSIGNED attribute is deprecated for columns of type FLOAT, DOUBLE, DECIMAL." | [activerecord/CHANGELOG.md#L141](https://github.com/rails/rails/blob/v8.0.0/activerecord/CHANGELOG.md#L141) |
| `BENCHMARK_MS` | "Deprecate `Benchmark.ms` core extension. The benchmark gem will become bundled in Ruby 3.5." | [activesupport/CHANGELOG.md#L59](https://github.com/rails/rails/blob/v8.0.0/activesupport/CHANGELOG.md#L59) |
| `RAKE_STATS` | "Deprecate `bin/rake stats` in favor of `bin/rails stats`." | [railties/CHANGELOG.md#L208](https://github.com/rails/rails/blob/v8.0.0/railties/CHANGELOG.md#L208) |

## Entries added

### High priority

| variable_name | kind | pattern target | rationale |
|---|---|---|---|
| `RUBY_VERSION` | breaking | Ruby 2.x or 3.0 / 3.1 in `Gemfile` / `.ruby-version` | Apps on older Ruby fail to bundle. |
| `ENUM_KWARGS` | breaking | `enum status:` keyword form at start of line | Models using the old form raise `ArgumentError` on class load. |

### Medium priority

| variable_name | kind | pattern target | rationale |
|---|---|---|---|
| `ENV_SCHEMA_CACHE` | breaking | `ENV["SCHEMA_CACHE"]` | Read/assign hook removed. |
| `ROUTES_MULTIPLE_PATHS` | deprecation | `get \[`, `post \[`, etc. at start of line | Removed at 8.1. |

### Low priority

| variable_name | kind | pattern target | rationale |
|---|---|---|---|
| `WARN_ON_RECORDS_FETCHED` | breaking | `warn_on_records_fetched_greater_than` | Existing config lines raise `NoMethodError` at boot. |
| `ALLOW_DEPRECATED_SINGULAR_ASSOCIATIONS_NAME` | breaking | `allow_deprecated_singular_associations_name` | Existing config lines raise `NoMethodError` at boot. |
| `COMMIT_TRANSACTION_ON_NON_LOCAL_RETURN` | breaking | `commit_transaction_on_non_local_return` | Existing config lines raise `NoMethodError` at boot. |
| `UNSIGNED_FLOAT_DECIMAL` | deprecation | `\bunsigned_(float|decimal)\b` | Cross-references `MYSQL_UNSIGNED` in `rails-81-patterns.yml` (8.1 removal). |
| `BENCHMARK_MS` | deprecation | `Benchmark.ms` | Cross-references `BENCHMARK_MS_REMOVED` in `rails-81-patterns.yml` (8.1 removal). |
| `RAKE_STATS` | deprecation | `rake stats` | The rake task continues to work at 8.0 with a deprecation warning. |

## Out of scope

Per the issue's "typical-app surface" scope, this PR skips gem-author / Rails-internal entries: DB-name argument to `cache_dump_filename`, `ActiveRecord::ConnectionAdapters::ConnectionPool#connection`, implicit lookup of unregistered DB adapters, `::STATS_DIRECTORIES` global. Typical apps do not call these directly.

## Test plan

- [x] New `low_priority` section added (the file did not previously have one).
- [x] `kind:` placed immediately after `name:` on every new entry.
- [x] All new patterns compile (Ruby `Regexp.new`).
- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml` passes.
- [x] `bin/validate-patterns` (all files) passes.
- [x] No existing entry, regex, priority grouping, or `dependencies:` block was modified.

## Cross-references

- `MYSQL_UNSIGNED` in `rails-81-patterns.yml` — 8.1 removal of `unsigned_float` / `unsigned_decimal`.
- `BENCHMARK_MS_REMOVED` in `rails-81-patterns.yml` — 8.1 removal of `Benchmark.ms`.
- `ROUTES_MULTIPLE_PATHS_REMOVED` in `rails-81-patterns.yml` — 8.1 removal of array-of-paths route form.

Refs #53 (overall `kind:` rollout)
