### PR TITLE
Catch gem-level runtime incompat via boot smoke test + pattern prereqs

### DIFF
--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -170,6 +170,7 @@ If user requests a multi-hop upgrade (e.g., 5.2 → 8.1):
 - `workflows/direct-detection-workflow.md` - How to run breaking change detection directly
 - `workflows/upgrade-report-workflow.md` - How to generate upgrade reports
 - `workflows/gem-compatibility-workflow.md` - **Load in Step 4.5** - Per-lockfile gem compatibility check against the target Rails version. Documents both the primary (`next_rails` `bundle_report compatibility`) and the secondary (railsbump.org API) and the rules for when to escalate.
+- `workflows/boot-smoke-test-workflow.md` - **Load in Step 4.6** - Run a Rails-loading command against `Gemfile.next` to catch gem-level runtime incompat that the resolver can't see (gems calling removed Rails internals or `require`-ing removed files).
 - `workflows/ci-sync-workflow.md` - **MANDATORY before opening the upgrade PR** - How to verify CI config matches the upgraded Gemfile
 - `workflows/app-update-preview-workflow.md` - How to generate app:update previews
 - **`upgrade-cleanup` companion plugin** - User-triggered. Removes dual-boot scaffolding and drops `NextRails.next?` / `NextRails.current?` branches. Deprecation triage stays with this skill for the next hop.
@@ -286,6 +287,39 @@ Determines which gems must be bumped before the Rails version change can resolve
 3. If any blockers exist, load references/gem-compatibility.md for
    the fork/replace/vendor playbook and the gem update order. Skip
    otherwise.
+```
+
+### Step 4.6: Boot Smoke Test on Gemfile.next
+```
+Catches the gem-internal incompatibilities that Step 4 (codebase grep) and
+Step 4.5 (resolver-level compat check) cannot see.
+
+A gem can declare loose Rails constraints — no upper bound on activerecord /
+activesupport — and `bundle_report compatibility` plus `bundle install` will
+both call it "compatible." But at runtime, the gem may:
+
+  - call a Rails internal that was removed at the target version
+    (e.g. database_cleaner-active_record 2.1.x calling
+    AR::ConnectionAdapters#schema_migration, removed in Rails 7.2)
+  - require a file that was removed at the target version
+    (e.g. jbuilder 2.11.x doing `require "active_support/proxy_object"`,
+    removed in Rails 8.0)
+
+These surface only when something boots Rails. Catching them here, before
+the report is written, lets them land in fix-before-bump where they belong
+instead of mid-implementation.
+
+1. Read: workflows/boot-smoke-test-workflow.md
+2. Run a Rails-loading command against Gemfile.next:
+     BUNDLE_GEMFILE=Gemfile.next bundle exec rspec --dry-run
+   (or `bin/rails runner "puts Rails.version"`, or `bundle exec rspec` if
+   the suite is fast enough — anything that triggers
+   `Bundler.require(*Rails.groups)` and the framework boot.)
+3. If boot fails, capture the LoadError / NoMethodError trace, identify
+   the offending gem (grep the bundle paths for the missing constant or
+   file), check rubygems for a newer version with target-Rails compat,
+   and add the bump to the fix-before-bump bucket for Step 5.
+4. Re-run the boot smoke test until it succeeds. Then proceed to Step 5.
 ```
 
 ### Step 5: Load Report Resources & Generate Reports

--- a/rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml
@@ -81,6 +81,11 @@ upgrade_findings:
       explanation: "fixture_path singular is deprecated in favor of fixture_paths plural"
       fix: "Change fixture_path to fixture_paths (array)"
       variable_name: "FIXTURE_PATH"
+      prereqs:
+        - gem: "rspec-rails"
+          min_version: "6.1.0"
+          reason: "config.fixture_paths= is forwarded from RSpec::Core::Configuration only on rspec-rails 6.1+. On 6.0.x the new setter raises NoMethodError."
+          when: "rspec-rails is present in the bundle"
 
     - name: "query_constraints deprecated"
       kind: "deprecation"

--- a/rails-upgrade/workflows/boot-smoke-test-workflow.md
+++ b/rails-upgrade/workflows/boot-smoke-test-workflow.md
@@ -1,0 +1,97 @@
+# Boot Smoke Test Workflow
+
+**When to run:** Step 4.6 of the upgrade workflow, after gem-compat (Step 4.5) and before report generation (Step 5).
+
+**Why this step exists:** Step 4 (codebase grep) only sees the user's own code. Step 4.5 (`next_rails bundle_report compatibility` / railsbump) only sees declared dependency constraints. Neither can detect a gem that resolves cleanly under the target Rails version but then crashes at boot because it calls a removed method or requires a removed file.
+
+A booted Rails process is the only signal that catches that class of failure.
+
+## Real examples this catches
+
+| Hop | Gem | Failure mode | What the resolver / static patterns see |
+|---|---|---|---|
+| 7.1 → 7.2 | `database_cleaner-active_record 2.1.x` | `NoMethodError: undefined method 'schema_migration' for #<...PostgreSQLAdapter>` at first cleaner call | Resolver: ✓ compatible (no upper bound on activerecord). Patterns: ✗ no app-code reference. |
+| 7.2 → 8.0 | `jbuilder 2.11.x` | `LoadError: cannot load such file -- active_support/proxy_object` at `Bundler.require` | Resolver: ✓ compatible (no upper bound on activesupport). Patterns: ✗ no app-code reference. |
+
+In both cases the gem ships in default Rails-generated apps and the user did nothing wrong — the gem itself needed a newer minor version with target-Rails support.
+
+## Procedure
+
+### 1. Pick a boot trigger
+
+Anything that loads `config/application.rb` is sufficient. Cheapest options first:
+
+```bash
+# Cheapest: just boot the framework
+BUNDLE_GEMFILE=Gemfile.next bundle exec rails runner "puts Rails.version"
+
+# Slightly heavier: load the test environment without running specs
+BUNDLE_GEMFILE=Gemfile.next bundle exec rspec --dry-run
+
+# Heaviest but most thorough: full suite under target Rails
+BUNDLE_GEMFILE=Gemfile.next bundle exec rspec
+# or
+BUNDLE_GEMFILE=Gemfile.next bundle exec rails test
+```
+
+Use `rails runner` first. If it boots cleanly, escalate to the full test suite — that catches gems whose problematic code only loads under a specific environment (e.g. test-only gems, eager-load-only paths).
+
+### 2. Diagnose a failure
+
+Boot failures usually show up as one of:
+
+- `LoadError: cannot load such file -- <path>` — a gem `require`s a file Rails removed.
+- `NoMethodError: undefined method '<x>' for <Rails internal>` — a gem calls a Rails API that was removed or renamed.
+- `ArgumentError` / `TypeError` from a Rails class load — a gem passes args in a now-unsupported shape.
+
+To find the offending gem:
+
+```bash
+# Search all bundled gem paths for the missing file / constant
+find $(bundle show --paths | tr '\n' ' ') -name "*.rb" 2>/dev/null \
+  | xargs grep -l '<missing-file-or-method>' 2>/dev/null
+```
+
+The output points at the gem version that needs to bump.
+
+### 3. Resolve
+
+For each offending gem:
+
+1. Check rubygems for a newer minor or patch with target-Rails support:
+   ```bash
+   curl -s https://rubygems.org/api/v1/versions/<gem>.json \
+     | ruby -rjson -e 'puts JSON.parse(STDIN.read).first(8).map{|x|x["number"]}'
+   ```
+2. Read the gem's CHANGELOG for the target-Rails-compat release.
+3. Add a fix-before-bump entry to the upgrade report's gem-update list, citing:
+   - The exact failure (`LoadError` / `NoMethodError` / etc.)
+   - The minimum compatible version
+   - Why a static check missed it (no upper bound declared)
+4. Bump the floor in the Gemfile (`gem "<gem>", "~> <new-floor>"`) and re-run `bundle install` for both lockfiles.
+
+### 4. Re-run boot
+
+Repeat steps 1–3 until boot succeeds under `Gemfile.next`. Then proceed to Step 5.
+
+## Output
+
+A short report block to merge into Step 5's Comprehensive Upgrade Report:
+
+```
+Boot smoke test (Step 4.6):
+
+  - Triggered: BUNDLE_GEMFILE=Gemfile.next bundle exec rspec --dry-run
+  - Result: PASS / FAIL with N gem bumps required
+
+If FAIL → bumps required (added to fix-before-bump):
+  - <gem> <old> → <new>: <one-line failure reason>
+  - ...
+```
+
+If the smoke test passes on the first run, record that explicitly — it is a positive signal that the resolver-level compat check covered everything for this hop.
+
+## Notes
+
+- The smoke test does not replace the post-bump test suite run in Step 6. It is a *boot* check, not a feature check. Step 6 still runs the full suite against both versions.
+- Skip this step only if there is no Gemfile.next yet (very early in dual-boot setup). In all other cases, run it.

--- a/rails-upgrade/workflows/direct-detection-workflow.md
+++ b/rails-upgrade/workflows/direct-detection-workflow.md
@@ -37,7 +37,46 @@ The pattern file contains:
 - `upgrade_findings.medium_priority` - Important patterns to search
 - `upgrade_findings.low_priority` - Lower-urgency patterns to search
 - Each pattern has: `name`, `kind`, `pattern`, `search_paths`, `explanation`, `fix`, `variable_name`
+- Each pattern may optionally declare `prereqs:` — a list of gem-version floors that must be in place for the suggested `fix:` to actually work. See "The `prereqs:` field" below.
 - `kind` is one of `breaking` / `deprecation` / `migration` / `optional` — see `CLAUDE.md` → "Assigning `kind:`" for the rubric. The bucket each finding lands in (see Step 4 / Output Format) is driven by `kind`, not by priority.
+
+#### The `prereqs:` field (optional)
+
+Some patterns describe a Rails-API change whose `fix:` only works on a *recent enough* version of a wrapper gem. The Rails API exists at the target version, but the gem that exposes it to the app may need a bump first.
+
+Example: at Rails 7.2 the `fixture_path=` setter on `ActiveSupport::TestCase` is deprecated in favor of `fixture_paths=` (plural array). `fixture_paths=` exists from Rails 7.1+ — but in an rspec project the setter goes through `RSpec::Core::Configuration`, which only forwards `fixture_paths=` from `rspec-rails 6.1.0+`. On `rspec-rails 6.0.x` the suggested fix raises `NoMethodError`.
+
+Declaring this in the pattern:
+
+```yaml
+- name: "fixture_path deprecated"
+  kind: "deprecation"
+  pattern: "fixture_path[^s]"
+  exclude: "fixture_paths"
+  search_paths:
+    - "test/"
+    - "spec/"
+    - "config/"
+  explanation: "fixture_path singular is deprecated in favor of fixture_paths plural"
+  fix: "Change fixture_path to fixture_paths (array)"
+  variable_name: "FIXTURE_PATH"
+  prereqs:
+    - gem: "rspec-rails"
+      min_version: "6.1.0"
+      reason: "config.fixture_paths= is forwarded from RSpec::Core::Configuration only on 6.1+"
+      when: "rspec-rails is present in the bundle"
+```
+
+When compiling findings:
+
+1. For each pattern with `prereqs:`, check the user's `Gemfile.lock`.
+2. For each prereq whose `when:` matches (or has no `when:`):
+   - If the gem is at or above `min_version`, ignore the prereq.
+   - If the gem is below `min_version`, add a fix-before-bump entry **for the prereq gem bump**, in addition to (and ordered before) the original finding.
+
+This makes the cascade explicit in the report — readers see "bump rspec-rails first, *then* rename fixture_path" instead of discovering the second step mid-implementation.
+
+`prereqs:` is optional. Most patterns describe Rails-only API changes and need none.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds two complementary mechanisms to the upgrade workflow for catching gem-level breakage that the current detection and compatibility steps cannot see:

1. **New Step 4.6: Boot Smoke Test on `Gemfile.next`** — between gem-compat (4.5) and report generation (5). Runs a Rails-loading command against the dual-boot file to surface gems that resolve cleanly but blow up at boot.
2. **Optional `prereqs:` field on detection patterns** — declares "the suggested `fix:` only works if gem X is at version Y or above." Lets the report show the cascade up front instead of letting users hit it mid-implementation.

## Motivation

A real 7.1 → 8.0 upgrade ran on a customer app this week. Two fix-before-bump items only surfaced *after* the version flip, because Step 4 (codebase grep) and Step 4.5 (resolver compat check) cannot see them:

| Hop | Gem | Failure | What the existing checks see |
|---|---|---|---|
| 7.2 | `database_cleaner-active_record 2.1.x` | `NoMethodError: undefined method 'schema_migration' for #<...PostgreSQLAdapter>` at first cleaner call | Resolver: compatible (no upper bound on activerecord). Patterns: no app-code reference. |
| 8.0 | `jbuilder 2.11.x` | `LoadError: cannot load such file -- active_support/proxy_object` at `Bundler.require` | Resolver: compatible (no upper bound on activesupport). Patterns: no app-code reference. |

Both gems ship in default Rails-generated apps. The signal that catches them is a Rails boot. Neither static grep nor a constraint resolver will.

Separately, on the same upgrade, the existing `fixture_path` deprecation pattern's `fix:` (rename to `fixture_paths`) silently requires `rspec-rails >= 6.1.0`. On 6.0.x the new setter raises `NoMethodError`. The pattern had no way to express that prereq, so users hit the cascade mid-implementation.

## Changes

### Step 4.6 + `boot-smoke-test-workflow.md`

- New step in `SKILL.md` between 4.5 and 5. Runs `BUNDLE_GEMFILE=Gemfile.next bundle exec rails runner ...` (or `rspec --dry-run` / `rspec`), diagnoses any `LoadError` / `NoMethodError`, identifies the offending gem, bumps its floor.
- New workflow file at `rails-upgrade/workflows/boot-smoke-test-workflow.md` documenting:
  - Boot trigger options (cheapest → heaviest).
  - Diagnosis recipes (LoadError / NoMethodError patterns).
  - The `find $(bundle show --paths) -name "*.rb" | xargs grep -l ...` recipe for identifying which gem references the missing constant or file.
  - Output format for the report.
  - Two real failure cases (`database_cleaner`, `jbuilder`) as illustrative examples.

The smoke test does **not** replace the post-bump test suite run in Step 6. This is a *boot* check, not a feature check.

### `prereqs:` field on patterns

- Documented in `rails-upgrade/workflows/direct-detection-workflow.md` (pattern format section), with a worked example using the FIXTURE_PATH pattern.
- Compilation rule: when a finding's pattern has `prereqs:`, check `Gemfile.lock`; if a prereq's `min_version` is not met (and `when:` matches), add a fix-before-bump entry for the prereq gem bump **before** the original finding in the report.
- Schema:
  ```yaml
  prereqs:
    - gem: "rspec-rails"
      min_version: "6.1.0"
      reason: "config.fixture_paths= is forwarded from RSpec::Core::Configuration only on rspec-rails 6.1+"
      when: "rspec-rails is present in the bundle"
  ```
- Added to the existing FIXTURE_PATH pattern in `rails-72-patterns.yml` as the first concrete usage.
- `prereqs:` is **optional**. Most patterns describe Rails-only API changes and need none.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml` returns `OK` with the new `prereqs:` field.
- [x] `SKILL.md` and `direct-detection-workflow.md` render correctly.

## Out of scope

- Adding `prereqs:` to other patterns. Doing one concrete example here; future patterns can add it as needed.
- Automated `Gemfile.lock` parsing for `prereqs:` resolution (the workflow describes the lookup, but doesn't automate it). The skill's existing pattern is "Claude reads the lockfile in the relevant step," which extends naturally.
