### PR TITLE
Grep .rspec for deprecation behavior in Step 2

### DIFF
--- a/rails-upgrade/references/deprecation-warnings.md
+++ b/rails-upgrade/references/deprecation-warnings.md
@@ -16,6 +16,27 @@ Deprecation warnings notify you that a specific feature (method, class, or API) 
 
 ## Finding Deprecation Warnings
 
+### Check Existing Deprecation Behavior First
+
+Before reading test logs, sweep for places that already override `ActiveSupport::Deprecation` behavior. Otherwise "no deprecation warnings in the log" can mean "they're being silenced", and "every test fails" can mean "they've been raising the whole time, unrelated to the upgrade." `config/application.rb` and `config/environments/*.rb` are not the only places this is configured: RSpec autoloads `-r` requires from `.rspec`, and test helpers can install hooks like `RSpec.configure { |c| c.raise_errors_for_deprecations! }`.
+
+```bash
+grep -rnE "raise_errors_for_deprecations|ActiveSupport::Deprecation\.(behavior|disallowed_behavior|silenced)\s*=|ActiveSupport::Deprecation\.silence\b" \
+  .rspec spec/.rspec spec/spec_helper.rb spec/rails_helper.rb Rakefile \
+  config/ spec/support/ lib/tasks/ 2>/dev/null
+```
+
+The trailing `silence\b` alternation catches the block form `ActiveSupport::Deprecation.silence do ... end` (or `{ ... }`), which is the recommended way to scope a silence to a single noisy call site. The `\b` word boundary keeps it from matching `silenced` (which is already covered by the assignment branch).
+
+A common gotcha is a single line in `.rspec`:
+
+```
+# .rspec
+-r raise_errors_for_deprecations
+```
+
+That installs an RSpec hook that raises on every `ActiveSupport::Deprecation.warn`. Easy to miss because nothing about it lives under `config/`.
+
 ### In Test Suite Logs
 
 If you have good test coverage, run your test suite and check the logs:

--- a/rails-upgrade/references/deprecation-warnings.md
+++ b/rails-upgrade/references/deprecation-warnings.md
@@ -18,15 +18,24 @@ Deprecation warnings notify you that a specific feature (method, class, or API) 
 
 ### Check Existing Deprecation Behavior First
 
-Before reading test logs, sweep for places that already override `ActiveSupport::Deprecation` behavior. Otherwise "no deprecation warnings in the log" can mean "they're being silenced", and "every test fails" can mean "they've been raising the whole time, unrelated to the upgrade." `config/application.rb` and `config/environments/*.rb` are not the only places this is configured: RSpec autoloads `-r` requires from `.rspec`, and test helpers can install hooks like `RSpec.configure { |c| c.raise_errors_for_deprecations! }`.
+Before reading test logs, sweep for places that already override deprecation behavior. Otherwise "no deprecation warnings in the log" can mean "they're being silenced", and "every test fails" can mean "they've been raising the whole time, unrelated to the upgrade." `config/application.rb` and `config/environments/*.rb` are not the only places this is configured: apps also use the `config.active_support.deprecation =` env DSL, Rails 7.1+ apps use the `deprecators` registry, RSpec autoloads `-r` requires from `.rspec`, and test helpers can install hooks like `RSpec.configure { |c| c.raise_errors_for_deprecations! }`. Minitest apps wire the same behavior from `test/test_helper.rb` and `test/support/`.
 
 ```bash
-grep -rnE "raise_errors_for_deprecations|ActiveSupport::Deprecation\.(behavior|disallowed_behavior|silenced)\s*=|ActiveSupport::Deprecation\.silence\b" \
+grep -rnE "raise_errors_for_deprecations|(ActiveSupport::Deprecation|Rails\.application\.deprecators|[A-Z]\w*\.deprecator)\.(behavior|disallowed_behavior|silenced)\s*=|(ActiveSupport::Deprecation|Rails\.application\.deprecators|[A-Z]\w*\.deprecator)\.silence\b|config\.active_support\.(deprecation|disallowed_deprecation|disallowed_deprecation_warnings|report_deprecations)\s*=" \
   .rspec spec/.rspec spec/spec_helper.rb spec/rails_helper.rb Rakefile \
-  config/ spec/support/ lib/tasks/ 2>/dev/null
+  config/ spec/support/ lib/tasks/ \
+  test/test_helper.rb test/support/ test/minitest/ 2>/dev/null
 ```
 
 The trailing `silence\b` alternation catches the block form `ActiveSupport::Deprecation.silence do ... end` (or `{ ... }`), which is the recommended way to scope a silence to a single noisy call site. The `\b` word boundary keeps it from matching `silenced` (which is already covered by the assignment branch).
+
+Which forms appear depends on the app's Rails version:
+
+- `config.active_support.deprecation=` / `ActiveSupport::Deprecation.behavior=` — Rails 3+ (classic global config)
+- `.rspec` `-r raise_errors_for_deprecations` / `raise_errors_for_deprecations!` — RSpec hook, any version
+- `Rails.application.deprecators` / `<Framework>.deprecator` (e.g. `ActiveRecord.deprecator`) — Rails 7.1+ (deprecators registry)
+
+Running this against a Rails 5–7.0 app and seeing no `deprecators` hits is expected, not a gap.
 
 A common gotcha is a single line in `.rspec`:
 

--- a/rails-upgrade/workflows/test-suite-verification-workflow.md
+++ b/rails-upgrade/workflows/test-suite-verification-workflow.md
@@ -49,23 +49,33 @@ fi
 
 #### 2a. Sweep for deprecation-behavior overrides
 
-Before running the suite, grep for places that change `ActiveSupport::Deprecation` behavior (raise / silence / disallow) so test results can be interpreted correctly. The obvious places (`config/application.rb`, `config/environments/*.rb`) are not enough. RSpec autoloads `-r` requires from `.rspec`, and test helpers can install hooks like `RSpec.configure { |c| c.raise_errors_for_deprecations! }`. Miss those and a "the upgrade broke tests" report can really be "every deprecation has been raising for months."
+Before running the suite, grep for places that change deprecation behavior (raise / silence / disallow) so test results can be interpreted correctly. The obvious places (`config/application.rb`, `config/environments/*.rb`) are not enough. Apps also use the `config.active_support.deprecation =` env DSL, Rails 7.1+ apps use the `deprecators` registry, RSpec autoloads `-r` requires from `.rspec`, and test helpers can install hooks like `RSpec.configure { |c| c.raise_errors_for_deprecations! }`. Miss those and a "the upgrade broke tests" report can really be "every deprecation has been raising for months."
 
 Sweep these locations:
 
 - `config/application.rb`, `config/environments/*.rb`, `config/initializers/*.rb`
 - `.rspec`, `spec/.rspec` (look for `-r raise_errors_for_deprecations` and similar autoloads)
 - `spec/spec_helper.rb`, `spec/rails_helper.rb`, `spec/support/**/*.rb`
+- `test/test_helper.rb`, `test/support/`, `test/minitest/` (Minitest apps)
 - `Rakefile`, `lib/tasks/*.rake`
 - Any Bundler-loaded test-group gem that wires deprecation behavior
 
 ```bash
-grep -rnE "raise_errors_for_deprecations|ActiveSupport::Deprecation\.(behavior|disallowed_behavior|silenced)\s*=|ActiveSupport::Deprecation\.silence\b" \
+grep -rnE "raise_errors_for_deprecations|(ActiveSupport::Deprecation|Rails\.application\.deprecators|[A-Z]\w*\.deprecator)\.(behavior|disallowed_behavior|silenced)\s*=|(ActiveSupport::Deprecation|Rails\.application\.deprecators|[A-Z]\w*\.deprecator)\.silence\b|config\.active_support\.(deprecation|disallowed_deprecation|disallowed_deprecation_warnings|report_deprecations)\s*=" \
   .rspec spec/.rspec spec/spec_helper.rb spec/rails_helper.rb Rakefile \
-  config/ spec/support/ lib/tasks/ 2>/dev/null
+  config/ spec/support/ lib/tasks/ \
+  test/test_helper.rb test/support/ test/minitest/ 2>/dev/null
 ```
 
 The trailing `silence\b` alternation catches the block form `ActiveSupport::Deprecation.silence do ... end`, which scopes silencing to a noisy call site and is otherwise easy to miss. The `\b` word boundary excludes `silenced` (already covered by the assignment branch).
+
+Which forms appear depends on the app's Rails version:
+
+- `config.active_support.deprecation=` / `ActiveSupport::Deprecation.behavior=` — Rails 3+ (classic global config)
+- `.rspec` `-r raise_errors_for_deprecations` / `raise_errors_for_deprecations!` — RSpec hook, any version
+- `Rails.application.deprecators` / `<Framework>.deprecator` (e.g. `ActiveRecord.deprecator`) — Rails 7.1+ (deprecators registry)
+
+Running this against a Rails 5–7.0 app and seeing no `deprecators` hits is expected, not a gap.
 
 #### 2b. Run the suite
 

--- a/rails-upgrade/workflows/test-suite-verification-workflow.md
+++ b/rails-upgrade/workflows/test-suite-verification-workflow.md
@@ -47,6 +47,28 @@ fi
 
 ### Step 2: Run the Test Suite
 
+#### 2a. Sweep for deprecation-behavior overrides
+
+Before running the suite, grep for places that change `ActiveSupport::Deprecation` behavior (raise / silence / disallow) so test results can be interpreted correctly. The obvious places (`config/application.rb`, `config/environments/*.rb`) are not enough. RSpec autoloads `-r` requires from `.rspec`, and test helpers can install hooks like `RSpec.configure { |c| c.raise_errors_for_deprecations! }`. Miss those and a "the upgrade broke tests" report can really be "every deprecation has been raising for months."
+
+Sweep these locations:
+
+- `config/application.rb`, `config/environments/*.rb`, `config/initializers/*.rb`
+- `.rspec`, `spec/.rspec` (look for `-r raise_errors_for_deprecations` and similar autoloads)
+- `spec/spec_helper.rb`, `spec/rails_helper.rb`, `spec/support/**/*.rb`
+- `Rakefile`, `lib/tasks/*.rake`
+- Any Bundler-loaded test-group gem that wires deprecation behavior
+
+```bash
+grep -rnE "raise_errors_for_deprecations|ActiveSupport::Deprecation\.(behavior|disallowed_behavior|silenced)\s*=|ActiveSupport::Deprecation\.silence\b" \
+  .rspec spec/.rspec spec/spec_helper.rb spec/rails_helper.rb Rakefile \
+  config/ spec/support/ lib/tasks/ 2>/dev/null
+```
+
+The trailing `silence\b` alternation catches the block form `ActiveSupport::Deprecation.silence do ... end`, which scopes silencing to a noisy call site and is otherwise easy to miss. The `\b` word boundary excludes `silenced` (already covered by the assignment branch).
+
+#### 2b. Run the suite
+
 Execute the appropriate test command:
 
 **For RSpec:**


### PR DESCRIPTION
Closes #100
Related https://github.com/ombulabs/claude-code_dual-boot-skill/pull/20

## Summary

- Add a "sweep for deprecation-behavior overrides" substep (2a) to `rails-upgrade/workflows/test-suite-verification-workflow.md` so the silence/raise/disallow check covers `.rspec`, `spec/.rspec`, `spec/spec_helper.rb`, `spec/rails_helper.rb`, `Rakefile`, and `spec/support/`, not just `config/`.
- Mirror the same guidance in `rails-upgrade/references/deprecation-warnings.md` under "Finding Deprecation Warnings", with the canonical `-r raise_errors_for_deprecations` example.

## Note for the maintainer

The originating report referenced `workflows/deprecation-triage-workflow.md` Step 2, but that exact file does not exist in this repo. I landed the change in the two closest spots: `test-suite-verification-workflow.md` (Step 2 = "Run the Test Suite") and `references/deprecation-warnings.md` ("Finding Deprecation Warnings"). Happy to relocate or split if there's a better target.

## Test plan

- [x] Docs-only change. Verified while exercising the skill on a legacy Rails app where `.rspec` autoloaded `raise_errors_for_deprecations` and the original silence-check guidance would have missed it.
- [x] `grep` recipe in the change exercised against that codebase and surfaces the `.rspec` autoload and the `RSpec.configure` hook.
