### PR TITLE
Rails 4.0 patterns: add new, correct unsafe fixes, note bridge gem

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -172,6 +172,16 @@ upgrade_findings:
       fix: "Add via: :get (or appropriate method) or replace with get/post/put/patch/delete helper"
       variable_name: "MATCH_WITHOUT_VIA"
 
+    - name: "config.whiny_nils"
+      kind: "breaking"
+      pattern: "config\\.whiny_nils"
+      exclude: ""
+      search_paths:
+        - "config/"
+      explanation: "config.whiny_nils was a Rails 2.x/3.x debugging affordance that made calls on nil raise a more helpful NoMethodError. Removed in Rails 4.0 — setting it raises NoMethodError on app boot"
+      fix: "Delete the config.whiny_nils = true line entirely. No replacement — Ruby's own nil-method errors are sufficient. False-positive watch: matches in comments documenting the removal; verify the hit is an actual assignment, not a comment"
+      variable_name: "WHINY_NILS"
+
   medium_priority:
     - name: "rescue_action method"
       kind: "breaking"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -168,8 +168,8 @@ upgrade_findings:
       search_paths:
         - "config/routes.rb"
         - "config/routes/"
-      explanation: "Rails 4.0 requires match routes to specify an HTTP method via: option"
-      fix: "Add via: :get (or appropriate method) or replace with get/post/put/patch/delete helper"
+      explanation: "Rails 4.0 requires match routes to specify an HTTP method via: option. Rails 3.2's bare match accepted all verbs, so any non-GET request (POST/PUT/PATCH/DELETE) currently served by a matchless match route will silently 404 if the fix narrows the verb list. Also note: on Rails 3.2 `via: :all` is treated as literal HTTP method name `\"ALL\"` and 404s every request — the any-verb special-casing only exists on Rails 4+. Verified on Rails 3.2.22.5 with Rack::MockRequest"
+      fix: "Default to the behavior-preserving explicit verb list: `via: [:get, :post, :put, :patch, :delete]`. Works identically on Rails 3.2 and 4.0+, zero behavior delta from the matchless-match default. Only narrow to `via: :get` (or another single verb) after a per-route audit confirms the route is GET-only — otherwise POST/PUT/etc. silently 404 after the rewrite, and the regression often first surfaces in production because spec suites rarely cover every verb on every route. NEVER emit `via: :all` — on Rails 3.2 it 404s every request. Verb-tightening is a separate workstream from the upgrade rewrite"
       variable_name: "MATCH_WITHOUT_VIA"
 
     - name: "config.whiny_nils"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -114,8 +114,8 @@ upgrade_findings:
       search_paths:
         - "app/"
         - "lib/"
-      explanation: "Dynamic finders like find_all_by_* are deprecated in Rails 4.0"
-      fix: "Replace find_all_by_column(val) with where(column: val)"
+      explanation: "Dynamic finders like find_all_by_* are deprecated in Rails 4.0 but continue to work because Rails 4.0 ships activerecord-deprecated_finders as a default dependency. The finders are actually removed in Rails 4.1, when the bridge gem is no longer bundled"
+      fix: "Two valid paths. (1) Defer: leave the calls in place for the 3.2 → 4.0 hop and rely on the bundled activerecord-deprecated_finders gem; rewrite at the 4.0 → 4.1 hop where the gem is no longer default. (2) Pre-bump cleanup: replace find_all_by_column(val) with where(column: val) — works on Rails 3.2 and 4.0+. Note the return-type shift: find_all_by_* returned an Array; where(...) returns an ActiveRecord::Relation. If downstream code uses Array-specific methods (.flatten, indexed access, Array#-), add .to_a"
       variable_name: "FIND_ALL_BY"
 
     - name: "Dynamic finders (find_or_create_by_*)"
@@ -125,8 +125,8 @@ upgrade_findings:
       search_paths:
         - "app/"
         - "lib/"
-      explanation: "Dynamic finders like find_or_create_by_* are deprecated in Rails 4.0"
-      fix: "Replace find_or_create_by_column(val) with find_or_create_by(column: val)"
+      explanation: "Dynamic finders like find_or_create_by_* are deprecated in Rails 4.0 but continue to work because Rails 4.0 ships activerecord-deprecated_finders as a default dependency. The finders are actually removed in Rails 4.1, when the bridge gem is no longer bundled"
+      fix: "Two valid paths. (1) Defer: leave the calls in place for the 3.2 → 4.0 hop and rely on the bundled activerecord-deprecated_finders gem; rewrite at the 4.0 → 4.1 hop. (2) Pre-bump cleanup: replace find_or_create_by_column(val) with find_or_create_by(column: val). Both forms work on Rails 3.2 and 4.0+, so the rewrite is backwards-compatible"
       variable_name: "FIND_OR_CREATE_BY"
 
     - name: "Dynamic finders (find_or_initialize_by_*)"
@@ -136,8 +136,8 @@ upgrade_findings:
       search_paths:
         - "app/"
         - "lib/"
-      explanation: "Dynamic finders like find_or_initialize_by_* are deprecated in Rails 4.0"
-      fix: "Replace find_or_initialize_by_column(val) with find_or_initialize_by(column: val)"
+      explanation: "Dynamic finders like find_or_initialize_by_* are deprecated in Rails 4.0 but continue to work because Rails 4.0 ships activerecord-deprecated_finders as a default dependency. The finders are actually removed in Rails 4.1, when the bridge gem is no longer bundled"
+      fix: "Two valid paths. (1) Defer: leave the calls in place for the 3.2 → 4.0 hop and rely on the bundled activerecord-deprecated_finders gem; rewrite at the 4.0 → 4.1 hop. (2) Pre-bump cleanup: replace find_or_initialize_by_column(val) with find_or_initialize_by(column: val). Both forms work on Rails 3.2 and 4.0+, so the rewrite is backwards-compatible"
       variable_name: "FIND_OR_INITIALIZE_BY"
 
     - name: "Association :readonly option on through"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -353,7 +353,7 @@ upgrade_findings:
       search_paths:
         - "spec/"
         - "test/"
-      explanation: "Rails 4.0 added request.headers.merge! as the preferred test request-header API, but request.env.merge! continues to work through at least Rails 7 — both APIs coexist. Rails 8 is expected to remove the env-based form (verify against the current Rails changelog before scheduling the rewrite). For a 3.2 → 4.0 hop, this is opt-in cleanup, not a required fix"
+      explanation: "Rails 4.0 added request.headers.merge! as the preferred test request-header API, but request.env.merge! continues to work in legacy ActionController::TestCase-style controller specs on every supported Rails version. The real forcing function is the Rails 5+ migration from ActionController::TestCase to ActionDispatch::IntegrationTest (the former was extracted to the rails-controller-testing gem in 5.1, still maintained). For a 3.2 → 4.0 hop, this is opt-in cleanup, not a required fix — no specific Rails version removes request.env.merge! outright"
       fix: "Skippable for the 3.2 → 4.0 hop — request.env.merge! still works on Rails 4+. If opting in: on Rails 4+ it is a 1:1 substitution, request.env.merge!(headers) → request.headers.merge!(headers). Trap on Rails 3.2: ActionDispatch::Http::Headers#merge! exists but the Rack-key normalization layer Rails 4 added is absent, so Rack-env-style keys (HTTP_AUTHORIZATION, HTTP_*) silently fail to reach the controller — a real hop saw ~65% of auth-heavy controller examples fail because the auth header stopped propagating on 3.2. If rewriting during the dual-boot window, defer to the Rails 4+ side; do not bulk-rewrite pre-bump"
       variable_name: "REQUEST_ENV_MERGE"
 

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -297,8 +297,8 @@ upgrade_findings:
       search_paths:
         - "app/"
         - "lib/"
-      explanation: "Rails 4.0 removed the options argument from assign_attributes"
-      fix: "Remove the second argument (e.g., without_protection: true)"
+      explanation: "Rails 4.0 removed the options argument from assign_attributes. On Rails 3.2, assign_attributes(attrs, as: :admin) (or without_protection: true) invokes role-based mass-assignment tied to attr_accessible :foo, as: :admin. Dropping the options hash pre-bump silently changes mass-assignment scope on remaining 3.2 deploys and may permit attribute writes that the role-scoped attr_accessible declaration would otherwise filter — a silent security regression"
+      fix: "Do NOT bulk-drop the second arg pre-bump. Two safe paths: (1) branch the call with NextRails.next? — `if NextRails.next? then obj.assign_attributes(attrs) else obj.assign_attributes(attrs, as: :admin) end`; or (2) keep the option-hash form and rely on the protected_attributes bridge gem on the next side, which preserves role-scoped attr_accessible on Rails 4+. Pick (1) when the role scope is genuinely unused; pick (2) when role-based mass assignment is load-bearing"
       variable_name: "ASSIGN_ATTRIBUTES_OPTIONS"
 
     - name: "request.env.merge! in tests"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -369,6 +369,19 @@ upgrade_findings:
       fix: "Lift the second arg into a where chain. Hash: Class.update_all(set, {col: v}) → Class.where(col: v).update_all(set). Array: Class.update_all(set, [\"x = ?\", v]) → Class.where(\"x = ?\", v).update_all(set). String: Class.update_all(set, \"x = 1\") → Class.where(\"x = 1\").update_all(set). Both forms work on Rails 3.2 so the rewrite is backwards-compatible. False-positive watch: single-arg update_all on a relation that already has a where chain is the modern form (no comma + brace/quote/bracket — should not match the regex); rare update_all(strings.join(\",\")) shapes can trigger on the inner comma-quote — verify the second token is an actual conditions arg"
       variable_name: "UPDATE_ALL_TWO_ARG"
 
+    - name: "Old-style finder (find(:first|:all|:last, conditions:))"
+      kind: "deprecation"
+      pattern: "find\\(\\s*:(first|all|last)"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+        - "spec/"
+        - "test/"
+      explanation: "find(:first/:all/:last, conditions: ..., order: ..., ...) is the legacy ARel-1.0-style finder. Deprecated in Rails 3.2 (still works), removed in Rails 4.1. On Rails 4.0 it continues to work because activerecord-deprecated_finders ships as a default dependency — the gem is removed at 4.1, at which point the form must be rewritten"
+      fix: "Two valid paths. (1) Defer: leave the calls in place for the 3.2 → 4.0 hop and rely on the bundled activerecord-deprecated_finders gem; rewrite at the 4.0 → 4.1 hop. (2) Pre-bump cleanup: lift each hash key into a chained relation method. Class.find(:first, conditions: c) → Class.where(c).first; Class.find(:first, conditions: c, order: o) → Class.where(c).order(o).first; Class.find(:all, conditions: c) → Class.where(c); Class.find(:last, conditions: c) → Class.where(c).last. All recipes work on Rails 3.2 and 4.0+ natively. Important semantic shift for the :all form: find(:all, ...) returned an Array; where(...) returns an ActiveRecord::Relation. Most call sites just iterate, so the bare where(c) rewrite is fine; add .to_a only when downstream uses Array-specific methods. False-positive watch: Enumerable#find(ifnone) accepts a positional argument as the default if no block matches, so array.find(:all) / hash.find(:first) etc. would technically match — verify the receiver is an ActiveRecord class or relation (not a plain Array/Hash/Range). Also watch for Capybara page.find(..., match: :first) — different API, leave alone"
+      variable_name: "OLD_FINDER"
+
   low_priority:
     - name: "request.env.merge! in tests"
       kind: "optional"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -140,6 +140,17 @@ upgrade_findings:
       fix: "Two valid paths. (1) Defer: leave the calls in place for the 3.2 → 4.0 hop and rely on the bundled activerecord-deprecated_finders gem; rewrite at the 4.0 → 4.1 hop. (2) Pre-bump cleanup: replace find_or_initialize_by_column(val) with find_or_initialize_by(column: val). Both forms work on Rails 3.2 and 4.0+, so the rewrite is backwards-compatible"
       variable_name: "FIND_OR_INITIALIZE_BY"
 
+    - name: "Dynamic finders (find_last_by_*)"
+      kind: "deprecation"
+      pattern: "find_last_by_"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+      explanation: "Dynamic finders like find_last_by_* are deprecated in Rails 4.0 but continue to work because Rails 4.0 ships activerecord-deprecated_finders as a default dependency. The finders are actually removed in Rails 4.1, when the bridge gem is no longer bundled"
+      fix: "Two valid paths. (1) Defer: leave the calls in place for the 3.2 → 4.0 hop and rely on the bundled activerecord-deprecated_finders gem; rewrite at the 4.0 → 4.1 hop. (2) Pre-bump cleanup: replace find_last_by_column(val) with where(column: val).last. Both forms work on Rails 3.2 and 4.0+, so the rewrite is backwards-compatible"
+      variable_name: "FIND_LAST_BY"
+
     - name: "Association :readonly option on through"
       kind: "breaking"
       pattern: "(has_many|has_and_belongs_to_many).*:?readonly(:|\\s*=>)"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -286,8 +286,8 @@ upgrade_findings:
       search_paths:
         - "config/"
         - "lib/"
-      explanation: "Rails 4.0 changed the config path key from 'config/routes' to 'config/routes.rb'"
-      fix: "Change config.paths[\"config/routes\"] to config.paths[\"config/routes.rb\"]"
+      explanation: "Rails 4.0 changed the config-paths key from 'config/routes' to 'config/routes.rb'. On Rails 3.2 only the un-suffixed key is populated; renaming pre-bump returns nil for the old key and the next chained call raises NoMethodError: undefined method `concat' for nil:NilClass at boot. The claim that Rails 3.2.13+ silently accepts either form is false — only Rails 4+ accepts the .rb-suffixed key"
+      fix: "Do NOT rename in place pre-bump — that breaks Rails 3.2 boot. Branch with NextRails.next?: `key = NextRails.next? ? \"config/routes.rb\" : \"config/routes\"; config.paths[key].concat(...)` (or duplicate the block inside `if NextRails.next? ... else ... end`). Once the app is fully on Rails 4+, drop the branch"
       variable_name: "CONFIG_ROUTES_PATH"
 
     - name: "assign_attributes with options hash"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -301,17 +301,6 @@ upgrade_findings:
       fix: "Do NOT bulk-drop the second arg pre-bump. Two safe paths: (1) branch the call with NextRails.next? — `if NextRails.next? then obj.assign_attributes(attrs) else obj.assign_attributes(attrs, as: :admin) end`; or (2) keep the option-hash form and rely on the protected_attributes bridge gem on the next side, which preserves role-scoped attr_accessible on Rails 4+. Pick (1) when the role scope is genuinely unused; pick (2) when role-based mass assignment is load-bearing"
       variable_name: "ASSIGN_ATTRIBUTES_OPTIONS"
 
-    - name: "request.env.merge! in tests"
-      kind: "migration"
-      pattern: "request\\.env\\.merge!"
-      exclude: ""
-      search_paths:
-        - "spec/"
-        - "test/"
-      explanation: "Rails 4.0 changed test request header API from request.env to request.headers. The catch: ActionDispatch::Http::Headers#merge! also exists on Rails 3.2, but the Rack-key normalization layer that Rails 4 added is absent. Test specs typically use Rack-env-style keys (HTTP_AUTHORIZATION, HTTP_*) because that is what request.env accepts; after a bulk request.env.merge! → request.headers.merge! rewrite, the same keys still work on Rails 4 but on Rails 3.2 the headers do not reach the controller and every authed request returns 400/401"
-      fix: "Do NOT bulk-rewrite pre-bump for any spec suite that uses request.env.merge! to set auth or content-type headers — a real hop saw ~65% of auth-heavy controller examples fail because the auth header silently stopped propagating on Rails 3.2. Defer to dual-boot: the next bundle's Rails 4 has the normalization, so the rewrite is correct there. On the 4+ side it is a 1:1 substitution — request.env.merge!(headers) → request.headers.merge!(headers). For codebases without auth-header specs (rare), the rewrite can run pack-by-pack with each pack's full spec suite as the gate"
-      variable_name: "REQUEST_ENV_MERGE"
-
     - name: "_run_validation_callbacks"
       kind: "breaking"
       pattern: "_run_validation_callbacks"
@@ -355,6 +344,18 @@ upgrade_findings:
       explanation: "Rails 4.0 is stricter about date parsing in YAML fixtures"
       fix: "Cast dynamic dates to strings: <%= 3.days.ago.to_s(:db) %>"
       variable_name: "FIXTURE_DATES"
+
+  low_priority:
+    - name: "request.env.merge! in tests"
+      kind: "optional"
+      pattern: "request\\.env\\.merge!"
+      exclude: ""
+      search_paths:
+        - "spec/"
+        - "test/"
+      explanation: "Rails 4.0 added request.headers.merge! as the preferred test request-header API, but request.env.merge! continues to work through at least Rails 7 — both APIs coexist. Rails 8 is expected to remove the env-based form (verify against the current Rails changelog before scheduling the rewrite). For a 3.2 → 4.0 hop, this is opt-in cleanup, not a required fix"
+      fix: "Skippable for the 3.2 → 4.0 hop — request.env.merge! still works on Rails 4+. If opting in: on Rails 4+ it is a 1:1 substitution, request.env.merge!(headers) → request.headers.merge!(headers). Trap on Rails 3.2: ActionDispatch::Http::Headers#merge! exists but the Rack-key normalization layer Rails 4 added is absent, so Rack-env-style keys (HTTP_AUTHORIZATION, HTTP_*) silently fail to reach the controller — a real hop saw ~65% of auth-heavy controller examples fail because the auth header stopped propagating on 3.2. If rewriting during the dual-boot window, defer to the Rails 4+ side; do not bulk-rewrite pre-bump"
+      variable_name: "REQUEST_ENV_MERGE"
 
 dependencies:
   protected_attributes:

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -309,8 +309,8 @@ upgrade_findings:
       search_paths:
         - "app/"
         - "lib/"
-      explanation: "Internal method _run_validation_callbacks was replaced in Rails 4.0"
-      fix: "Replace with run_callbacks(:validation)"
+      explanation: "Internal method _run_validation_callbacks was removed in Rails 4.0 with no deprecation warning"
+      fix: "Replace with run_callbacks(:validation) — the public API exists on Rails 3.2 (via ActiveModel::Validations::Callbacks / ActiveSupport::Callbacks) and 4.0+, so the swap is backwards-compatible. Real-world incidence is low — typically only ActiveModel form objects and edge-case validators hit this internal API"
       variable_name: "RUN_VALIDATION_CALLBACKS"
 
     - name: "select('distinct ...').pluck"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -356,6 +356,19 @@ upgrade_findings:
       fix: "Cast dynamic dates to strings: <%= 3.days.ago.to_s(:db) %>"
       variable_name: "FIXTURE_DATES"
 
+    - name: "update_all with hash/string/array conditions (two-arg form)"
+      kind: "deprecation"
+      pattern: "update_all\\([^)]*,\\s*[\\{\"'\\[]"
+      exclude: ""
+      search_paths:
+        - "app/"
+        - "lib/"
+        - "spec/"
+        - "test/"
+      explanation: "Class.update_all(set, conditions) two-arg form is deprecated in Rails 4.0 and removed in 4.1. The new form is Class.where(conditions).update_all(set). Covers hash, string, and array condition shapes. Note: activerecord-deprecated_finders does NOT bridge update_all — the bundled gem covers find(:first/:all/:last) and dynamic finders only, so this form must be rewritten before reaching Rails 4.1"
+      fix: "Lift the second arg into a where chain. Hash: Class.update_all(set, {col: v}) → Class.where(col: v).update_all(set). Array: Class.update_all(set, [\"x = ?\", v]) → Class.where(\"x = ?\", v).update_all(set). String: Class.update_all(set, \"x = 1\") → Class.where(\"x = 1\").update_all(set). Both forms work on Rails 3.2 so the rewrite is backwards-compatible. False-positive watch: single-arg update_all on a relation that already has a where chain is the modern form (no comma + brace/quote/bracket — should not match the regex); rare update_all(strings.join(\",\")) shapes can trigger on the inner comma-quote — verify the second token is an actual conditions arg"
+      variable_name: "UPDATE_ALL_TWO_ARG"
+
   low_priority:
     - name: "request.env.merge! in tests"
       kind: "optional"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -308,8 +308,8 @@ upgrade_findings:
       search_paths:
         - "spec/"
         - "test/"
-      explanation: "Rails 4.0 changed test request header API from request.env to request.headers"
-      fix: "Replace request.env.merge!(headers) with request.headers.merge!(headers)"
+      explanation: "Rails 4.0 changed test request header API from request.env to request.headers. The catch: ActionDispatch::Http::Headers#merge! also exists on Rails 3.2, but the Rack-key normalization layer that Rails 4 added is absent. Test specs typically use Rack-env-style keys (HTTP_AUTHORIZATION, HTTP_*) because that is what request.env accepts; after a bulk request.env.merge! → request.headers.merge! rewrite, the same keys still work on Rails 4 but on Rails 3.2 the headers do not reach the controller and every authed request returns 400/401"
+      fix: "Do NOT bulk-rewrite pre-bump for any spec suite that uses request.env.merge! to set auth or content-type headers — a real hop saw ~65% of auth-heavy controller examples fail because the auth header silently stopped propagating on Rails 3.2. Defer to dual-boot: the next bundle's Rails 4 has the normalization, so the rewrite is correct there. On the 4+ side it is a 1:1 substitution — request.env.merge!(headers) → request.headers.merge!(headers). For codebases without auth-header specs (rare), the rewrite can run pack-by-pack with each pack's full spec suite as the gate"
       variable_name: "REQUEST_ENV_MERGE"
 
     - name: "_run_validation_callbacks"


### PR DESCRIPTION
## Summary

Rails 3.2 → 4.0 patterns: add missing entries, correct fixes that were unsafe as written, note `activerecord-deprecated_finders` as the bundled bridge gem on relevant entries.

- **New entries:** `config.whiny_nils`, `find_last_by_*`, `update_all` 2-arg, `find(:first/:all/:last, …)`.
- **Fix corrections** (each previously naive in a way that breaks 3.2 boot, leaks data, or silently 404s):
  - `config.paths["config/routes"]` — in-place rename breaks 3.2 boot; now uses `NextRails.next?`.
  - `assign_attributes` options — bulk-dropping the hash silently expands mass-assignment scope on 3.2; now offers branch-or-bridge.
  - `request.env.merge!` — 3.2 lacks Rack-key normalization, breaks ~65% of auth specs on bulk rewrite; defer to dual-boot.
  - `MATCH_WITHOUT_VIA` — `via: :get` default narrows verbs and 404s POST/PUT routes; `via: :all` 404s every request on 3.2; default now `[:get, :post, :put, :patch, :delete]`.
- **Reclassification:** `request.env.merge!` is `kind: optional` in `low_priority` — works through Rails 7, no specific removal version. Adds the `low_priority:` section.
- **Bridge gem note:** three dynamic finder entries (`find_all_by_*`, `find_or_create_by_*`, `find_or_initialize_by_*`) now mention `activerecord-deprecated_finders` ships by default in Rails 4.0 and removes at 4.1. Scope of the gem verified against upstream README (does NOT cover association options).
- `_run_validation_callbacks` explanation upgraded: silent removal, public API backwards-compatible on 3.2.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml` clean.
- [ ] Reviewer spot-checks regex for `update_all` 2-arg and `find(:first/:all/:last)` against representative 3.x code.
- [ ] Reviewer confirms `low_priority:` section addition matches the convention used in other version files.