### PR TITLE
Rails 4.0 patterns: correct JS-compressor fix, revert ASSETS_COMPRESS over-specification

### DIFF
--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -191,6 +191,7 @@ If user requests a multi-hop upgrade (e.g., 5.2 → 8.1):
 - `references/multi-hop-strategy.md` - Multi-version planning
 - `references/testing-checklist.md` - Comprehensive testing
 - `references/gem-compatibility.md` - Gem update order and the "no compatible version" playbook (fork / vendor / replace). Load only when Step 4.5's compatibility check produced blockers.
+- `references/js-compressor-sprockets-mismatch.md` - Keeping terser / closure-compiler working when the target Rails pins Sprockets to the 2.x line. Load only when JS_COMPRESSOR_GEM_MISMATCH fires.
 
 ### Detection Pattern Resources
 - `detection-scripts/patterns/rails-*.yml` - Version-specific patterns for direct detection

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -193,6 +193,16 @@ upgrade_findings:
       fix: "Delete the config.whiny_nils = true line entirely. No replacement — Ruby's own nil-method errors are sufficient. False-positive watch: matches in comments documenting the removal; verify the hit is an actual assignment, not a comment"
       variable_name: "WHINY_NILS"
 
+    - name: "Modern JS-compressor gem requires newer Sprockets than Rails 4 ships"
+      kind: "breaking"
+      pattern: "gem\\s+['\"](terser|closure-compiler)['\"]"
+      exclude: ""
+      search_paths:
+        - "Gemfile"
+      explanation: "Only fires when terser or closure-compiler is in the Gemfile — apps on plain uglifier never see this entry. Modern JS-compressor gems (terser, closure-compiler) declare a runtime dependency on `sprockets/digest_utils`, which exists only in Sprockets >= 3. Rails 4.0 locks Sprockets to the 2.x line via sprockets-rails. On Rails 4.0's next side the bundle resolves cleanly (gemspec passes railsbump's check) but the gem's railtie loads at boot and raises `LoadError: cannot load such file -- sprockets/digest_utils`. Invisible to railsbump because the failure is at require-time, after the bundle is locked. Apps reach for terser deliberately (modern JS the abandoned uglifier 4.2.0 cannot compile: ES2020 optional chaining `?.`, UTF-8 source), so you cannot simply swap it for uglifier on the next side without losing those assets. For uglifier itself the breaking versions are 4.x+, so a hit on a bare `gem \"uglifier\"` needs a version-pin check"
+      fix: "Keep terser on the next side but stop its railtie from auto-loading on Sprockets 2.x: `gem \"terser\", require: false` (require: false is mandatory or boot dies with the LoadError). Add `gem \"uglifier\", \">= 1.3.0\"` on the next side too, only so the `:uglifier` symbol resolves in environment configs, then register Terser as the real compressor at compile time via a rake task hooked on assets:environment. The current (Rails 3.2) side keeps plain `gem \"terser\"` (its railtie is harmless there). Full recipe with Gemfile, env-config, and rake-task examples: rails-upgrade/references/js-compressor-sprockets-mismatch.md"
+      variable_name: "JS_COMPRESSOR_GEM_MISMATCH"
+
     - name: "validates_format_of with multiline anchors (^...$)"
       kind: "breaking"
       pattern: "validates_format_of.*\\bwith(?::|\\s*=>)\\s*/[^/]*[\\^$]"

--- a/rails-upgrade/references/js-compressor-sprockets-mismatch.md
+++ b/rails-upgrade/references/js-compressor-sprockets-mismatch.md
@@ -1,0 +1,120 @@
+# JS Compressor vs Sprockets During a Dual-Boot Upgrade
+
+**When to read this:** the `JS_COMPRESSOR_GEM_MISMATCH` detection pattern fired, i.e. the
+Gemfile has `gem "terser"` (or `closure-compiler`) and you are dual-booting across a Rails
+version that locks Sprockets to the 2.x line (Rails 4.0 via `sprockets-rails`).
+
+If the app uses plain `uglifier`, you do not need this file. The standard
+`config.assets.js_compressor = :uglifier` fix is enough.
+
+---
+
+## The problem in one paragraph
+
+Modern JS-compressor gems (terser, closure-compiler) `require "sprockets/digest_utils"` from
+their railtie. That file exists only in **Sprockets >= 3**. Rails 4.0 pins Sprockets to **2.x**.
+The next bundle *resolves* fine (so `railsbump` / `next_rails` report nothing), but at **boot**
+Bundler auto-requires the gem, the railtie runs, and you get:
+
+```
+LoadError: cannot load such file -- sprockets/digest_utils
+```
+
+The failure is require-time, not resolve-time, which is why dependency checkers miss it.
+
+## Why not just use uglifier on the next side?
+
+Because apps add terser on purpose. Uglifier's last release (4.2.0, Sep 2019) is abandoned and
+cannot compile modern JS:
+
+- ES2020 optional chaining `?.` and nullish coalescing `??` — not parsed at all, even with
+  `harmony: true`.
+- UTF-8 source files — uglifier defaults to US-ASCII and errors on smart quotes, em-dashes, etc.
+
+Swapping terser for uglifier on the next side would drop exactly the assets that motivated
+terser. The goal is to keep terser working on **both** sides.
+
+---
+
+## The recipe
+
+### Gemfile
+
+```ruby
+group :assets do
+  if next?
+    gem "uglifier", ">= 1.3.0"   # ONLY so the :uglifier symbol resolves in env configs
+    gem "terser", require: false  # the real compressor; require: false is MANDATORY (see below)
+  else
+    gem "terser"                  # current side: railtie is harmless on Sprockets 2.x there
+  end
+end
+```
+
+**Why `require: false` on the next side is mandatory.** Without it, Bundler auto-requires
+terser at boot, the railtie runs `config.assets.configure { ... }`, that block references
+`Terser::Compressor`, which autoloads and `require "sprockets/digest_utils"` — and boot dies.
+With `require: false`, the railtie never runs; you load terser yourself at compile time.
+
+**Why uglifier is still present on the next side.** Env configs set
+`config.assets.js_compressor = :uglifier` (see below). Sprockets 2.x resolves `:uglifier` to its
+built-in `UglifierCompressor`. The gem must be installed for the symbol to resolve, even though
+its JS engine never actually runs in production — the rake task replaces it with Terser first.
+
+### Environment configs (production / staging / etc.)
+
+```ruby
+config.assets.js_compressor = :uglifier
+```
+
+Unconditional is fine: `:uglifier` resolves on both Sprockets 2.x (next) and the current side.
+
+### Rake task: swap in Terser at compile time
+
+Hook on `assets:environment` (runs before compilation) and replace the registered `:uglifier`
+processor with Terser:
+
+```ruby
+# lib/tasks/assets.rake
+Rake::Task["assets:environment"].enhance do
+  require "terser"
+  env = Rails.application.assets
+  env = env.instance_variable_get(:@environment) if env.is_a?(Sprockets::Index)
+
+  terser = Terser.new(output: { ecma: 2015 })
+  env.js_compressor = nil  # unregisters the :uglifier bundle processor set in env configs
+  env.register_bundle_processor("application/javascript", :js_compressor) do |context, data|
+    if context.pathname.to_s.include?("/webpack/") || context.pathname.basename.to_s.include?(".min.")
+      data            # already minified — skip
+    else
+      terser.compile(data)
+    end
+  end
+  Rails.application.assets = env.index if Rails.application.assets.is_a?(Sprockets::Index)
+end
+```
+
+On a current Rails 3.2 side the equivalent uses `Sprockets::LazyCompressor` (defined in
+ActionPack 3.2, not the Sprockets gem) wrapping a `Terser.new`, gated on `config.assets.compress`
+so it only runs in production-like environments.
+
+---
+
+## Cleanup on the next hop (when Sprockets reaches 3/4)
+
+Once the app is fully on a Rails version that ships Sprockets 3/4, unwind the workaround:
+
+1. Drop `uglifier` — it was only a symbol shim.
+2. Drop `require: false` on terser — Sprockets 3/4 integrates `Terser::Compressor` natively via
+   the railtie.
+3. Delete the rake-task swap — terser registers itself.
+4. Remove the `:uglifier` assignment / any `NextRails.next?` guards in env configs.
+
+---
+
+## Notes
+
+- Use `NextRails.next?` for any runtime branching, never `respond_to?` or `Gem::Version`
+  comparisons.
+- The exact hop where this bites is wherever Sprockets is still pinned to 2.x — for the
+  3.2 → 4.0 upgrade that is the 4.0 side. An app that already has Sprockets 3/4 will not hit it.


### PR DESCRIPTION
## Summary

I was unsure if adding this as PR, because the usage of `terser` seems too specific, but then I thought there might be more apps using it in Rails 3.2, and it is better if we got a reference on how we solved it one time.

But I'm open to your opinions on whether we should keep them or not.
