### PR TITLE
Add Rails 8.0 undocumented breaking change: belongs_to association query_constraints removed in favor of foreign_key

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml
@@ -44,6 +44,16 @@ upgrade_findings:
       fix: "Remove sqlite3_deprecated_warning configuration"
       variable_name: "SQLITE3_WARNING"
 
+    - name: "belongs_to/has_many query_constraints: option"
+      kind: "breaking"
+      pattern: "query_constraints:"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 8.0 removes the `query_constraints:` association option (deprecated in 7.2; activerecord/CHANGELOG.md 7.2: 'Association option `query_constraints` is deprecated in favor of `foreign_key`.'). At 8.0 it raises `ActiveRecord::ConfigurationError` at class load, so the model — and the app — fails to boot. Not mentioned in the official upgrade guide or release notes. Verify the match is an association option, not an unrelated query_constraints: hash key."
+      fix: "Pass the composite key as an Array to `foreign_key:` instead: `belongs_to :activity, foreign_key: [:activity_id, :school_id]`. AR maps an Array `foreign_key` to query_constraints internally on both 7.2 and 8.0, so the change is behavior-preserving and needs no dual-boot branch."
+      variable_name: "QUERY_CONSTRAINTS_OPTION"
+
   medium_priority:
     - name: "Redis cache store"
       kind: "optional"

--- a/rails-upgrade/version-guides/upgrade-7.2-to-8.0.md
+++ b/rails-upgrade/version-guides/upgrade-7.2-to-8.0.md
@@ -163,9 +163,42 @@ rbenv local 3.3.0
 
 ---
 
+#### 6. `query_constraints:` association option removed (composite foreign keys)
+
+**What Changed:**
+Rails 8.0 **removes** the `query_constraints:` option on associations (`belongs_to`/`has_many`/etc.). It was deprecated in Rails 7.2 and now raises `ActiveRecord::ConfigurationError` **at class load**, so the app fails to boot.
+
+**Detection Pattern:**
+```ruby
+# app/models/*.rb
+belongs_to :activity, query_constraints: [:activity_id, :school_id]
+```
+
+**Error (Rails 8.0):**
+```
+ActiveRecord::ConfigurationError:
+  Setting `query_constraints:` option on `ActivityParticipant.belongs_to :activity`
+  is not allowed. To get the same behavior, use the `foreign_key` option instead.
+```
+
+**Fix — pass the composite key as an `Array` to `foreign_key:`:**
+```ruby
+# BEFORE (7.2 deprecation → 8.0 raises)
+belongs_to :activity, query_constraints: [:activity_id, :school_id]
+
+# AFTER (works on Rails 7.2 AND 8.0)
+belongs_to :activity, foreign_key: [:activity_id, :school_id]
+```
+
+This is **behavior-preserving and version-agnostic**: when `foreign_key:` is given an `Array`, ActiveRecord internally maps it back to `query_constraints` (in both 7.2 and 8.0), so no dual-boot (`NextRails.next?`) branch is needed. On 7.2 it also silences the deprecation warning.
+  
+> ⚠️ Not in the official Rails Upgrade Guide or the 7.2/8.0 release notes — documented only in `activerecord` `CHANGELOG.md` (7.2) and the source. A **boot smoke test** (`bin/rails runner`) is the reliable way to catch it.
+
+---
+
 ### 🟡 MEDIUM PRIORITY
 
-#### 6. Solid Cache (Optional)
+#### 7. Solid Cache (Optional)
 
 **What Changed:**
 Rails 8.0 defaults to Solid Cache for caching (database-backed).
@@ -198,7 +231,7 @@ config.cache_store = :solid_cache_store
 
 ---
 
-#### 7. Solid Queue (Optional)
+#### 8. Solid Queue (Optional)
 
 **What Changed:**
 Rails 8.0 defaults to Solid Queue for background jobs (database-backed).
@@ -231,7 +264,7 @@ config.active_job.queue_adapter = :solid_queue
 
 ---
 
-#### 8. Solid Cable (Optional)
+#### 9. Solid Cable (Optional)
 
 **What Changed:**
 Rails 8.0 defaults to Solid Cable for WebSockets (database-backed).
@@ -262,7 +295,7 @@ production:
 
 ---
 
-#### 9. Docker/Thruster for Production
+#### 10. Docker/Thruster for Production
 
 **What Changed:**
 Rails 8.0 apps include Dockerfile and Thruster gem.
@@ -281,7 +314,7 @@ Thruster provides:
 
 ---
 
-#### 10. Kamal Deployment
+#### 11. Kamal Deployment
 
 **What Changed:**
 Rails 8.0 includes Kamal configuration for deployment.


### PR DESCRIPTION
## What

Adds the `query_constraints:` association option removal to the **7.2 → 8.0** upgrade guidance, in two places:
  
- `version-guides/upgrade-7.2-to-8.0.md` — new HIGH PRIORITY breaking-change section with detection pattern, the exact `ConfigurationError`, and an OLD/NEW fix.
- `detection-scripts/patterns/rails-80-patterns.yml` — a `high_priority` / `kind: breaking` entry (`QUERY_CONSTRAINTS_OPTION`) so the change is auto-detected.

## Why

Rails 8.0 **removes** the `query_constraints:` option on associations (`belongs_to`/`has_many`/etc.). It was deprecated in 7.2 and now **raises `ActiveRecord::ConfigurationError` at class load**, so any model using it prevents the app from booting:

```
ActiveRecord::ConfigurationError:
  Setting `query_constraints:` option on `ActivityParticipant.belongs_to :activity`
  is not allowed. To get the same behavior, use the `foreign_key` option instead.
```

The fix is behavior-preserving and version-agnostic — pass the composite key as an `Array` to `foreign_key:`:

```ruby
# BEFORE (7.2 deprecation → 8.0 raises)
belongs_to :activity, query_constraints: [:activity_id, :school_id]

# AFTER (works on Rails 7.2 AND 8.0)
belongs_to :activity, foreign_key: [:activity_id, :school_id]
```

ActiveRecord maps an `Array` `foreign_key` back to `query_constraints` internally on **both** 7.2 and 8.0, so no `NextRails.next?` dual-boot branch is needed, and it also silences the 7.2 deprecation warning.        
  
## Why it was missing

This breaking change is **not documented in the official Rails Upgrade Guide or the 7.2/8.0 release notes** — only in the `activerecord` CHANGELOG (7.2) and the source. It surfaced during a real 7.2 → 8.0 upgrade via a **boot smoke
  test** (`bin/rails runner`), which raised the `ConfigurationError` on class load; an upgrade docs only review would have missed it.

## Detection-pattern note

The pattern is intentionally the broad `query_constraints:` rather than an association-anchored regex. For a `kind: breaking` boot failure, recall matters more than precision: the broad form also catches multi-line `belongs_to` declarations (where the option is on a continuation line), at the cost of an occasional false positive on an unrelated `query_constraints:` hash key, which is cheap to dismiss in the verification step. It correctly skips the legitimate composite-PK class macro `query_constraints :col1, :col2` (space before the symbol, no adjacent colon).

## Sources

- `activerecord-7.2.3/CHANGELOG.md:620` — *"Association option `query_constraints` is deprecated in favor of `foreign_key`."* (Nikita Vasilevsky)
- `activerecord-7.2.3/CHANGELOG.md:809-810` — `Array` `foreign_key` replaces the composite-key use of `query_constraints`.
- `activerecord-8.0.5/lib/active_record/reflection.rb:525-530` — `raise ConfigurationError` on `query_constraints:`.
- `reflection.rb` (7.2 `:541` and 8.0 `:533`) — `if options[:foreign_key].is_a?(Array): options[:query_constraints] = options.delete(:foreign_key)` — the `Array` → `query_constraints` mapping, identical in both versions.
