### PR TITLE
docs: add no-test-suite smoke fallback

### DIFF
--- a/rails-upgrade/SKILL.md
+++ b/rails-upgrade/SKILL.md
@@ -167,6 +167,7 @@ If user requests a multi-hop upgrade (e.g., 5.2 → 8.1):
 
 ### Workflow Guides (Load when generating deliverables)
 - `workflows/test-suite-verification-workflow.md` - **MANDATORY FIRST STEP** - How to run and verify test suite
+- `workflows/no-test-suite-smoke-workflow.md` - **Load from Step 1 when no runnable RSpec/Minitest suite exists** - Rails boot, routes, migration-status, and build smoke baseline with partial-confidence reporting
 - `workflows/direct-detection-workflow.md` - How to run breaking change detection directly
 - `workflows/upgrade-report-workflow.md` - How to generate upgrade reports
 - `workflows/gem-compatibility-workflow.md` - **Load in Step 4.5** - Per-lockfile gem compatibility check against the target Rails version. Documents both the primary (`next_rails` `bundle_report compatibility`) and the secondary (railsbump.org API) and the rules for when to escalate.
@@ -232,12 +233,17 @@ When user requests an upgrade, follow this workflow:
 2. Detect test framework (RSpec, Minitest, or both)
 3. Run test suite with: bundle exec rspec OR bundle exec rails test
 4. Capture results: total tests, passing, failing, pending
-5. If ANY tests fail:
+5. If no runnable test suite exists:
+   - Load: workflows/no-test-suite-smoke-workflow.md
+   - Run the safe read-only smoke baseline: Rails boot, test-env boot when possible, routes load, migration status, and asset/build command if present
+   - Record baseline confidence as partial
+   - Continue only if boot/routes checks pass and the user accepts the risk of proceeding without real tests
+6. If ANY tests fail:
    - STOP the upgrade process
    - Report failing tests to user
    - Offer to help fix failing tests
    - Do NOT proceed until all tests pass
-6. If all tests pass:
+7. If all tests pass:
    - Record baseline metrics (test count, coverage if available)
    - Proceed to Step 2
 ```

--- a/rails-upgrade/workflows/no-test-suite-smoke-workflow.md
+++ b/rails-upgrade/workflows/no-test-suite-smoke-workflow.md
@@ -1,0 +1,119 @@
+# No-Test-Suite Smoke Workflow
+
+**Purpose:** Provide a concrete baseline check when a Rails app has no RSpec or Minitest suite.
+
+**When to use:** Step 1 of the Rails upgrade workflow, only after test-suite detection finds no runnable `spec/` or `test/` suite.
+
+This workflow is not a replacement for adding tests. It is a minimum boot and routing baseline so the upgrade report can say exactly what was checked before proceeding.
+
+---
+
+## Step 1: Confirm There Is No Runnable Suite
+
+Check both files and Gemfile entries before declaring "no tests":
+
+```bash
+test -d spec || test -d test
+grep -E "rspec-rails|minitest|capybara|factory_bot_rails" Gemfile Gemfile.lock
+```
+
+If there are test directories or gems, return to `test-suite-verification-workflow.md` and run the real suite. Use this fallback only when no runnable suite exists.
+
+---
+
+## Step 2: Run Rails Boot Checks
+
+Start with the cheapest command that loads the Rails environment:
+
+```bash
+bundle exec rails runner "puts Rails.version"
+```
+
+If the app has multiple environments or credentials constraints, also check test-mode boot:
+
+```bash
+RAILS_ENV=test bundle exec rails runner "puts Rails.env"
+```
+
+Record PASS or FAIL and the exact error. A boot failure blocks the upgrade until the user decides whether to fix the baseline first.
+
+---
+
+## Step 3: Check Routes And Migrations
+
+These commands catch common baseline failures without needing a test suite:
+
+```bash
+bundle exec rails routes >/tmp/rails-routes.txt
+bundle exec rails db:migrate:status
+```
+
+If `db:migrate:status` cannot run because the database is unavailable, report it as "not verified" rather than fabricating a pass. Do not create or migrate a database unless the user asked for that setup.
+
+---
+
+## Step 4: Run Asset Or Build Checks When Available
+
+Only run commands that already exist in the app:
+
+```bash
+bundle exec rails assets:precompile
+bin/vite build
+yarn build
+npm run build
+```
+
+Pick the app's actual build path from its files (`package.json`, `vite.config.*`, `app/assets`, `config/webpacker.yml`, or Propshaft/Sprockets config). If no asset build exists, record "not applicable."
+
+---
+
+## Step 5: Optional Manual Smoke URLs
+
+If the app can boot locally, collect the most important URLs from routes:
+
+```bash
+bundle exec rails server
+```
+
+Then manually or with curl check only safe read-only endpoints, for example:
+
+```bash
+curl -I http://localhost:3000/
+curl -I http://localhost:3000/users/sign_in
+```
+
+Do not submit forms, mutate data, or hit admin/customer actions as part of this fallback.
+
+---
+
+## Output Format
+
+```markdown
+## No-Test-Suite Smoke Baseline
+
+**Status:** PASS / FAIL / PARTIAL
+**Reason this fallback ran:** No runnable RSpec or Minitest suite was detected.
+
+| Check | Command | Result |
+|---|---|---|
+| Rails boot | `bundle exec rails runner "puts Rails.version"` | PASS |
+| Test env boot | `RAILS_ENV=test bundle exec rails runner "puts Rails.env"` | PASS |
+| Routes load | `bundle exec rails routes` | PASS |
+| Migration status | `bundle exec rails db:migrate:status` | NOT VERIFIED - database unavailable |
+| Asset/build check | `<actual command>` | PASS / NOT APPLICABLE |
+
+**Upgrade risk:** High. This app has no automated suite. Add focused tests before or during the first upgrade hop, and treat every generated change as requiring manual verification.
+```
+
+---
+
+## Stop Conditions
+
+Stop and report instead of proceeding when:
+
+- Rails cannot boot in the current environment.
+- Routes cannot load.
+- The app has a test suite but it fails to run.
+- A required database or credential is missing and the user has not authorized setup.
+
+If the fallback passes, continue with the upgrade workflow, but mark baseline confidence as `partial` and keep recommending real test coverage.

--- a/rails-upgrade/workflows/no-test-suite-smoke-workflow.md
+++ b/rails-upgrade/workflows/no-test-suite-smoke-workflow.md
@@ -10,14 +10,18 @@ This workflow is not a replacement for adding tests. It is a minimum boot and ro
 
 ## Step 1: Confirm There Is No Runnable Suite
 
-Check both files and Gemfile entries before declaring "no tests":
+Check for actual test **files**, not just gem presence. `minitest` ships with every Rails app (it is a transitive dependency of `activesupport` in virtually every `Gemfile.lock`), so a gem match alone does not mean a runnable suite exists. Relying on it sends abandoned-test-setup apps back to `test-suite-verification-workflow.md`, which finds nothing to run and bounces them right back here, an infinite loop.
 
 ```bash
-test -d spec || test -d test
-grep -E "rspec-rails|minitest|capybara|factory_bot_rails" Gemfile Gemfile.lock
+# Test file presence (the deciding signal)
+test -d spec && find spec -name "*_spec.rb" | grep -q .
+test -d test && find test -name "*_test.rb" | grep -q .
+
+# Gemfile only (never Gemfile.lock), explicit test gems only
+grep -E "rspec-rails|minitest-rails" Gemfile
 ```
 
-If there are test directories or gems, return to `test-suite-verification-workflow.md` and run the real suite. Use this fallback only when no runnable suite exists.
+Treat the app as having **no runnable suite** unless at least one test file is found. If test files do exist, return to `test-suite-verification-workflow.md` and run the real suite. Use this fallback only when no runnable suite exists.
 
 ---
 
@@ -44,9 +48,11 @@ Record PASS or FAIL and the exact error. A boot failure blocks the upgrade until
 These commands catch common baseline failures without needing a test suite:
 
 ```bash
-bundle exec rails routes >/tmp/rails-routes.txt
+bundle exec rails routes > tmp/rails-routes.txt 2>&1
 bundle exec rails db:migrate:status
 ```
+
+Redirect both stdout and stderr (`2>&1`): routing errors such as a bad constant in `routes.rb` print to stderr, and dropping them lets the command look like it succeeded with an empty output file. Write to the app's own `tmp/` directory rather than `/tmp`, which can be read-only or sandboxed in CI, Docker, and macOS App Sandbox contexts and would fail the check for the wrong reason.
 
 If `db:migrate:status` cannot run because the database is unavailable, report it as "not verified" rather than fabricating a pass. Do not create or migrate a database unless the user asked for that setup.
 
@@ -69,17 +75,18 @@ Pick the app's actual build path from its files (`package.json`, `vite.config.*`
 
 ## Step 5: Optional Manual Smoke URLs
 
-If the app can boot locally, collect the most important URLs from routes:
+If the app can boot locally, start the server in the background, capture its PID, and **always shut it down afterward** so an orphaned server does not hold port 3000 and cause conflicts in later steps:
 
 ```bash
-bundle exec rails server
-```
+bundle exec rails server &
+SERVER_PID=$!
+sleep 5  # wait for boot
 
-Then manually or with curl check only safe read-only endpoints, for example:
-
-```bash
+# Check only safe, read-only endpoints, for example:
 curl -I http://localhost:3000/
 curl -I http://localhost:3000/users/sign_in
+
+kill $SERVER_PID 2>/dev/null
 ```
 
 Do not submit forms, mutate data, or hit admin/customer actions as part of this fallback.
@@ -113,7 +120,6 @@ Stop and report instead of proceeding when:
 
 - Rails cannot boot in the current environment.
 - Routes cannot load.
-- The app has a test suite but it fails to run.
 - A required database or credential is missing and the user has not authorized setup.
 
 If the fallback passes, continue with the upgrade workflow, but mark baseline confidence as `partial` and keep recommending real test coverage.

--- a/rails-upgrade/workflows/test-suite-verification-workflow.md
+++ b/rails-upgrade/workflows/test-suite-verification-workflow.md
@@ -157,14 +157,15 @@ Could not find:
 - spec/ directory (RSpec)
 - test/ directory (Minitest)
 
-This is a significant risk for upgrading. Consider:
-1. Adding test coverage before upgrading
-2. Proceeding with extra manual testing (not recommended)
+This is a significant risk for upgrading. Before proceeding:
+1. Run the no-test-suite smoke baseline in `workflows/no-test-suite-smoke-workflow.md`
+2. Record boot, routes, migration-status, and asset/build results
+3. Recommend adding focused test coverage before or during the first upgrade hop
 
-Do you want to proceed without tests? (This is risky)
+Do you want to proceed with only a smoke baseline? (This is risky)
 ```
 
-**Action:** Warn user strongly, but allow them to proceed if they acknowledge the risk.
+**Action:** Load `workflows/no-test-suite-smoke-workflow.md`, run the safe read-only baseline checks, and mark baseline confidence as `partial` if they pass. If any boot/routes check fails, stop the upgrade until the baseline is fixed or the user explicitly accepts the blocker.
 
 #### Tests Take Too Long (> 10 minutes)
 
@@ -351,6 +352,7 @@ Before proceeding past this step:
 - [ ] Test suite executed successfully
 - [ ] All tests pass (0 failures)
 - [ ] Baseline metrics recorded
+- [ ] If no suite exists: no-test-suite smoke baseline recorded as `partial`
 - [ ] User informed of results
 - [ ] If failures: user understands they must fix tests first
 


### PR DESCRIPTION
## Summary

Adds a concrete fallback for #113 when a Rails app has no runnable RSpec or Minitest suite.

Changes:

- Adds `workflows/no-test-suite-smoke-workflow.md` with safe read-only baseline checks for Rails boot, test-env boot, routes, migration status, and asset/build commands
- Wires the fallback into Step 1 of `rails-upgrade/SKILL.md`
- Updates the test-suite verification workflow so "no tests found" records a partial-confidence smoke baseline instead of only warning and proceeding

This keeps the existing "real test suite first" rule intact: the fallback only applies when no runnable suite exists, and boot/routes failures still stop the upgrade.

## Validation

- `docker run --rm -v /Users/stephenkall/Desktop/BEAN/.tmp/bean-gh488-rails-skill-validate:/app -w /app ruby:3.3-alpine sh -lc 'ruby bin/validate-patterns && ruby bin/validate-patterns --self-test'` -> all pattern files OK, self-test 8/8
- `git diff --check`
- `rg -n "no-test-suite-smoke|No-Test-Suite|no runnable test suite|baseline confidence" rails-upgrade/SKILL.md rails-upgrade/workflows/test-suite-verification-workflow.md rails-upgrade/workflows/no-test-suite-smoke-workflow.md`

Note: local macOS system Ruby 2.6 cannot run `bin/validate-patterns` because `Psych.safe_load_file` is unavailable, so validation was run with Ruby 3.3 in Docker.

Submitted by Bean Labs as a public free-service contribution; acceptance is still pending maintainer review.
