### PR TITLE
Add check_pending! removal coverage (7.1 deprecation, 7.2 removal)

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-71-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-71-patterns.yml
@@ -54,6 +54,19 @@ upgrade_findings:
       variable_name: "LIB_AUTOLOAD"
 
   medium_priority:
+    - name: "ActiveRecord::Migration.check_pending! deprecated"
+      kind: "deprecation"
+      pattern: "Migration\\.check_pending!"
+      exclude: ""
+      search_paths:
+        - "test/"
+        - "spec/"
+        - "config/"
+        - "lib/"
+      explanation: "ActiveRecord::Migration.check_pending! is deprecated in Rails 7.1 in favor of check_all_pending!, which loops through all database configurations. It still works but emits a deprecation warning, and is removed in Rails 7.2."
+      fix: "Replace ActiveRecord::Migration.check_pending! with ActiveRecord::Migration.check_all_pending!"
+      variable_name: "MIGRATION_CHECK_PENDING"
+
     - name: "SQLite database in db/ directory"
       kind: "optional"
       pattern: "database:\\s*db/.*\\.sqlite3"

--- a/rails-upgrade/detection-scripts/patterns/rails-71-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-71-patterns.yml
@@ -63,7 +63,7 @@ upgrade_findings:
         - "spec/"
         - "config/"
         - "lib/"
-      explanation: "ActiveRecord::Migration.check_pending! is deprecated in Rails 7.1 in favor of check_all_pending!, which loops through all database configurations. It still works but emits a deprecation warning, and is removed in Rails 7.2."
+      explanation: "ActiveRecord::Migration.check_pending! is deprecated in Rails 7.1 in favor of check_all_pending!, which loops through all database configurations. It still works but emits a deprecation warning, and is removed in Rails 7.2. Commonly found in test_helper.rb/rails_helper.rb, but also configured by healthcheck gems (e.g. rails-healthcheck) to run against a /healthcheck route."
       fix: "Replace ActiveRecord::Migration.check_pending! with ActiveRecord::Migration.check_all_pending!"
       variable_name: "MIGRATION_CHECK_PENDING"
 

--- a/rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml
@@ -59,6 +59,19 @@ upgrade_findings:
       fix: "Migrate all secrets to Rails.application.credentials"
       variable_name: "SECRETS_REMOVED"
 
+    - name: "ActiveRecord::Migration.check_pending! removed"
+      kind: "breaking"
+      pattern: "Migration\\.check_pending!"
+      exclude: ""
+      search_paths:
+        - "test/"
+        - "spec/"
+        - "config/"
+        - "lib/"
+      explanation: "ActiveRecord::Migration.check_pending! was deprecated in Rails 7.1 and is removed in Rails 7.2. Calling it raises NoMethodError, which breaks test suite startup when invoked from test_helper.rb or rails_helper.rb."
+      fix: "Replace ActiveRecord::Migration.check_pending! with ActiveRecord::Migration.check_all_pending!"
+      variable_name: "MIGRATION_CHECK_PENDING_REMOVED"
+
   medium_priority:
     - name: "serialize syntax change"
       kind: "breaking"

--- a/rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-72-patterns.yml
@@ -68,7 +68,7 @@ upgrade_findings:
         - "spec/"
         - "config/"
         - "lib/"
-      explanation: "ActiveRecord::Migration.check_pending! was deprecated in Rails 7.1 and is removed in Rails 7.2. Calling it raises NoMethodError, which breaks test suite startup when invoked from test_helper.rb or rails_helper.rb."
+      explanation: "ActiveRecord::Migration.check_pending! was deprecated in Rails 7.1 and is removed in Rails 7.2. Calling it raises NoMethodError. When invoked from test_helper.rb or rails_helper.rb it breaks test suite startup; when configured by a healthcheck gem (e.g. rails-healthcheck) it instead raises at runtime on the /healthcheck route in production."
       fix: "Replace ActiveRecord::Migration.check_pending! with ActiveRecord::Migration.check_all_pending!"
       variable_name: "MIGRATION_CHECK_PENDING_REMOVED"
 

--- a/rails-upgrade/version-guides/upgrade-7.0-to-7.1.md
+++ b/rails-upgrade/version-guides/upgrade-7.0-to-7.1.md
@@ -287,6 +287,26 @@ config.active_record.attributes_for_inspect = [:id, :name, :email]
 config.active_record.attributes_for_inspect = :all
 ```
 
+#### 12. `ActiveRecord::Migration.check_pending!` Deprecated
+
+**What Changed:**
+`ActiveRecord::Migration.check_pending!` is deprecated in favor of `check_all_pending!`, which loops through all configured databases. It still works in 7.1 but emits a deprecation warning, and is removed entirely in Rails 7.2. Commonly found in `test_helper.rb` or `rails_helper.rb`.
+
+**Detection Pattern:**
+```ruby
+# test/test_helper.rb or spec/rails_helper.rb
+ActiveRecord::Migration.check_pending!
+```
+
+**Fix:**
+```ruby
+# BEFORE
+ActiveRecord::Migration.check_pending!
+
+# AFTER
+ActiveRecord::Migration.check_all_pending!
+```
+
 ---
 
 ## New Features

--- a/rails-upgrade/version-guides/upgrade-7.0-to-7.1.md
+++ b/rails-upgrade/version-guides/upgrade-7.0-to-7.1.md
@@ -290,7 +290,7 @@ config.active_record.attributes_for_inspect = :all
 #### 12. `ActiveRecord::Migration.check_pending!` Deprecated
 
 **What Changed:**
-`ActiveRecord::Migration.check_pending!` is deprecated in favor of `check_all_pending!`, which loops through all configured databases. It still works in 7.1 but emits a deprecation warning, and is removed entirely in Rails 7.2. Commonly found in `test_helper.rb` or `rails_helper.rb`.
+`ActiveRecord::Migration.check_pending!` is deprecated in favor of `check_all_pending!`, which loops through all configured databases. It still works in 7.1 but emits a deprecation warning, and is removed entirely in Rails 7.2. Commonly found in `test_helper.rb` or `rails_helper.rb`, but also set up by healthcheck gems (e.g. [`rails-healthcheck`](https://github.com/linqueta/rails-healthcheck)) to run on every `/healthcheck` request.
 
 **Detection Pattern:**
 ```ruby

--- a/rails-upgrade/version-guides/upgrade-7.0-to-7.1.md
+++ b/rails-upgrade/version-guides/upgrade-7.0-to-7.1.md
@@ -294,7 +294,7 @@ config.active_record.attributes_for_inspect = :all
 
 **Detection Pattern:**
 ```ruby
-# test/test_helper.rb or spec/rails_helper.rb
+# test/test_helper.rb, spec/rails_helper.rb, or config/initializers/*.rb (e.g. healthcheck gems)
 ActiveRecord::Migration.check_pending!
 ```
 

--- a/rails-upgrade/version-guides/upgrade-7.1-to-7.2.md
+++ b/rails-upgrade/version-guides/upgrade-7.1-to-7.2.md
@@ -184,7 +184,7 @@ Rails.application.credentials.dig(:production, :api_key)
 #### 6. `ActiveRecord::Migration.check_pending!` Removed
 
 **What Changed:**
-`ActiveRecord::Migration.check_pending!` was deprecated in Rails 7.1 and is removed in Rails 7.2. Calling it raises `NoMethodError`. When invoked from `test_helper.rb` or `rails_helper.rb` it breaks test-suite startup. Use `check_all_pending!`, which checks every configured database.
+`ActiveRecord::Migration.check_pending!` was deprecated in Rails 7.1 and is removed in Rails 7.2. Calling it raises `NoMethodError`. When invoked from `test_helper.rb` or `rails_helper.rb` it breaks test-suite startup; when configured by a healthcheck gem (e.g. [`rails-healthcheck`](https://github.com/linqueta/rails-healthcheck)) it instead raises at runtime on the `/healthcheck` route in production, even with no pending migration. Use `check_all_pending!`, which checks every configured database.
 
 **Detection Pattern:**
 ```ruby

--- a/rails-upgrade/version-guides/upgrade-7.1-to-7.2.md
+++ b/rails-upgrade/version-guides/upgrade-7.1-to-7.2.md
@@ -188,7 +188,7 @@ Rails.application.credentials.dig(:production, :api_key)
 
 **Detection Pattern:**
 ```ruby
-# test/test_helper.rb or spec/rails_helper.rb
+# test/test_helper.rb, spec/rails_helper.rb, or config/initializers/*.rb (e.g. healthcheck gems)
 ActiveRecord::Migration.check_pending!
 ```
 

--- a/rails-upgrade/version-guides/upgrade-7.1-to-7.2.md
+++ b/rails-upgrade/version-guides/upgrade-7.1-to-7.2.md
@@ -181,9 +181,31 @@ Rails.application.credentials.dig(:production, :api_key)
 
 ---
 
+#### 6. `ActiveRecord::Migration.check_pending!` Removed
+
+**What Changed:**
+`ActiveRecord::Migration.check_pending!` was deprecated in Rails 7.1 and is removed in Rails 7.2. Calling it raises `NoMethodError`. When invoked from `test_helper.rb` or `rails_helper.rb` it breaks test-suite startup. Use `check_all_pending!`, which checks every configured database.
+
+**Detection Pattern:**
+```ruby
+# test/test_helper.rb or spec/rails_helper.rb
+ActiveRecord::Migration.check_pending!
+```
+
+**Fix:**
+```ruby
+# BEFORE
+ActiveRecord::Migration.check_pending!
+
+# AFTER
+ActiveRecord::Migration.check_all_pending!
+```
+
+---
+
 ### 🟡 MEDIUM PRIORITY
 
-#### 6. serialize Requires Type Parameter
+#### 7. serialize Requires Type Parameter
 
 **What Changed:**
 `serialize` now requires explicit `type:` or `coder:` parameter.
@@ -208,7 +230,7 @@ serialize :preferences, coder: JSON
 
 ---
 
-#### 7. fixture_path → fixture_paths
+#### 8. fixture_path → fixture_paths
 
 **What Changed:**
 Singular `fixture_path` deprecated in favor of plural.
@@ -230,7 +252,7 @@ self.fixture_paths = ["#{Rails.root}/test/fixtures"]
 
 ---
 
-#### 8. query_constraints Deprecated
+#### 9. query_constraints Deprecated
 
 **What Changed:**
 `query_constraints` is deprecated.
@@ -243,7 +265,7 @@ has_many :posts, foreign_key: [:author_id, :author_type]
 
 ---
 
-#### 9. Mailer Test args: → params:
+#### 10. Mailer Test args: → params:
 
 **What Changed:**
 Mailer assertion helpers change `args:` to `params:`.
@@ -265,7 +287,7 @@ assert_enqueued_email_with UserMailer, :welcome, params: { user: user }
 
 ---
 
-#### 10. Queue Adapter Must Support `at:` for Testing
+#### 11. Queue Adapter Must Support `at:` for Testing
 
 **What Changed:**
 Tests now require queue adapters to support scheduling with `at:` option.
@@ -281,7 +303,7 @@ If using custom queue adapter in tests, ensure it supports `at:` option for sche
 
 ---
 
-#### 11. alias_attribute Behavior Change
+#### 12. alias_attribute Behavior Change
 
 **What Changed:**
 `alias_attribute` now applies attribute methods to the aliased attribute too.


### PR DESCRIPTION
## Summary

Adds detection patterns and version-guide coverage for `ActiveRecord::Migration.check_pending!`, reported missing in #117.

The reporter framed this as a Rails 8.0 rename, but the actual ActiveRecord source tells a different story. I verified it against a local `rails/rails` checkout at each version tag:

| Version | `check_pending!` state |
|---------|------------------------|
| 7.0 | Exists, no warning |
| 7.1 | Deprecated, emits warning; `check_all_pending!` added |
| 7.2 | Removed (only `check_all_pending!` remains) |
| 8.0 | Gone |

It was deleted in [`02f66fe3e2`](https://github.com/rails/rails/commit/02f66fe3e25cef2b0dec8bca26e777fe788af35c) ("Remove deprecated `ActiveRecord::Migration.check_pending` method"), first shipped in v7.2.0. So this is a 7.1 deprecation plus a 7.2 removal, not an 8.0 rename. Coverage is placed accordingly.

## Changes

- `rails-71-patterns.yml` → `medium_priority`, `kind: deprecation` (`MIGRATION_CHECK_PENDING`)
- `rails-72-patterns.yml` → `high_priority`, `kind: breaking` (`MIGRATION_CHECK_PENDING_REMOVED`)
- `upgrade-7.0-to-7.1.md` → new #12 (deprecation)
- `upgrade-7.1-to-7.2.md` → new #6 HIGH (removal); MEDIUM entries renumbered 7-12

Fix in both cases: replace `ActiveRecord::Migration.check_pending!` with `ActiveRecord::Migration.check_all_pending!`. The regex `Migration\.check_pending!` does not false-match the private `check_pending_migrations` helper.

## Verification

- `bin/validate-patterns` passes on both touched pattern files.
- Line numbers and removal commit confirmed against a local Rails checkout at tags v7.0.0 / v7.1.0 / v7.2.0 / v8.0.0.

Closes #117
