### PR TITLE
Add expectations for remaining rails-40 patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,13 @@ This file captures project-specific conventions Claude should follow when workin
   - Checks: YAML parses, required top-level keys present, the eight required pattern keys present on each entry, every `pattern` / `exclude` regex compiles, and the `kind:` value is one of the allowed enum values (`breaking`, `deprecation`, `migration`, `optional`)
   - Exits 0 on success, 1 on any failure with a per-file error report
 
+- `bin/test-patterns` runs fixture tests for a pattern file against its sibling `*.expectations.yml` (e.g. `rails-40-patterns.yml` + `rails-40-patterns.expectations.yml`). It confirms a pattern's regex actually matches what its explanation claims and skips what it shouldn't — `validate-patterns` only confirms the regex compiles, not that it's correct. Pure-stdlib Ruby, same shape as `bin/validate-patterns`.
+  - `bin/test-patterns` tests every pattern file that has an expectations sibling; files without one are reported `SKIP`, not a failure
+  - `bin/test-patterns path/to/file.yml` tests one or more specific files
+  - `bin/test-patterns --self-test` runs built-in fixture assertions. CI runs this alongside the fixture-test step
+  - Expectations are keyed by `variable_name` and list `match` (lines the pattern MUST flag) and `no_match` (lines it MUST NOT flag) — see the worked example in `rails-40-patterns.expectations.yml`
+  - Exits 0 on success, 1 on any failure with a per-pattern error report
+
 ## Version guides (`rails-upgrade/version-guides/*.md`)
 
 - **Do NOT include "Difficulty" or "Estimated Time" in the header.** These are subjective, application-dependent, and drift out of date. Keep the header minimal: title, Ruby requirement, and the attribution line.
@@ -26,6 +33,7 @@ This file captures project-specific conventions Claude should follow when workin
 - Each pattern needs: `name`, `kind` (one of `breaking` / `deprecation` / `migration` / `optional` — see "Assigning kind" below), `pattern` (regex), `exclude` (regex, empty string if none), `search_paths`, `explanation`, `fix`, `variable_name`. Place `kind:` immediately after `name:` for visual scannability.
 - Include a `dependencies` section for any bridge/compatibility gems mentioned in the guide.
 - **Required before committing any change to a detection pattern file:** run `bin/validate-patterns` (or `bin/validate-patterns path/to/file.yml` for the file you touched). Do not commit a pattern change without a clean run; broken YAML or schema drift in this directory breaks the skill at runtime. See the `## Repository tooling` section above for what the script checks.
+- **New pattern? Add a fixture expectation.** Every new `variable_name` needs a `match`/`no_match` entry in the sibling `*.expectations.yml` file (create the file if the version doesn't have one yet), then run `bin/test-patterns path/to/file.yml` clean before committing. Exception: a pattern whose `pattern` is `""` (pure path-based detection, e.g. `VENDOR_PLUGINS`) can never flag a line and should stay uncovered — note why in a comment instead of forcing a fixture.
 
 ## Assigning priority (🔴 HIGH / 🟡 MEDIUM / 🟢 LOW)
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ We welcome contributions! Here's how you can help:
 - Keep content factual and based on official Rails documentation
 - Include code examples with BEFORE/AFTER patterns
 - Test detection patterns against real codebases when possible
+- New detection pattern? Add a `match`/`no_match` fixture to its `*.expectations.yml` file and run `bin/test-patterns` before opening a PR
 - Attribute sources appropriately
 
 ## License

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.expectations.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.expectations.yml
@@ -18,9 +18,27 @@
 # Run with:
 #   bin/test-patterns rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
 #
-# --- Worked example -------------------------------------------------------
-# This file seeds ONE pattern as the template. Replicate the same match /
-# no_match shape for every other variable_name in the pattern file.
+# VENDOR_PLUGINS is intentionally uncovered: its pattern is "" (path-only
+# detection via search_paths), so flagged? always returns false and no
+# match line could ever pass.
+
+ATTR_ACCESSIBLE:
+  match:
+    - "  attr_accessible :name, :email"
+  no_match:
+    - "  attr_accessor :name, :email"
+
+ATTR_PROTECTED:
+  match:
+    - "  attr_protected :admin"
+  no_match:
+    - "  attr_accessor :admin"
+
+REQUIRE_STRONG_PARAMS:
+  match:
+    - "require 'strong_parameters'"
+  no_match:
+    - "require 'strong_password'"
 
 SCOPE_WITHOUT_LAMBDA:
   # Pattern: "scope\\s+:\\w+\\s*,\\s*where"
@@ -35,3 +53,199 @@ SCOPE_WITHOUT_LAMBDA:
     - "  scope :active, -> { where(active: true) }"
     # wrapped in an explicit lambda — also correct, must not flag
     - "  scope :active, lambda { where(active: true) }"
+
+DEFAULT_SCOPE_WITHOUT_BLOCK:
+  match:
+    - "  default_scope where(active: true)"
+    - "  default_scope :order => 'created_at'"
+  no_match:
+    - "  default_scope { where(active: true) }"
+
+ASSOCIATION_CONDITIONS:
+  match:
+    - "  has_many :items, :conditions => \"active = 1\""
+  no_match:
+    - "  has_many :items, -> { where(active: true) }"
+
+ASSOCIATION_ORDER:
+  match:
+    - "  has_many :items, :order => 'position ASC'"
+  no_match:
+    # underscore before "order" (sort_order) must not trip the [^_] guard
+    - "  has_many :items, :sort_order => 'asc'"
+
+ASSOCIATION_EXTEND:
+  match:
+    - "  has_many :items, :extend => ItemsExtension"
+  no_match:
+    - "  has_many :items, -> { extending ItemsExtension }"
+
+ASSOCIATION_UNIQ:
+  match:
+    - "  has_many :items, :uniq => true"
+  no_match:
+    - "  has_many :items, -> { distinct }"
+
+FINDER_SQL:
+  match:
+    - "  has_many :items, :finder_sql => 'SELECT * FROM items'"
+  no_match:
+    - "  has_many :items, -> { where(active: true) }"
+
+FIND_ALL_BY:
+  match:
+    - "User.find_all_by_email(email)"
+  no_match:
+    - "User.where(email: email)"
+
+FIND_OR_CREATE_BY:
+  match:
+    - "User.find_or_create_by_email(email)"
+  no_match:
+    - "User.find_or_create_by(email: email)"
+
+FIND_OR_INITIALIZE_BY:
+  match:
+    - "User.find_or_initialize_by_email(email)"
+  no_match:
+    - "User.find_or_initialize_by(email: email)"
+
+FIND_LAST_BY:
+  match:
+    - "User.find_last_by_email(email)"
+  no_match:
+    - "User.where(email: email).last"
+
+ASSOCIATION_READONLY:
+  match:
+    - "  has_many :items, :through => :orders, :readonly => true"
+  no_match:
+    - "  has_many :items, :through => :orders"
+
+RUBY_VERSION:
+  match:
+    - "ruby '1.8.7'"
+  no_match:
+    - "ruby '2.0.0'"
+
+MATCH_WITHOUT_VIA:
+  match:
+    - "  match '/users', to: 'users#index'"
+  no_match:
+    # via: present — the exclude regex must suppress this
+    - "  match '/users', to: 'users#index', via: :get"
+    # not a `match` route at all
+    - "  get '/users', to: 'users#index'"
+
+WHINY_NILS:
+  match:
+    - "  config.whiny_nils = true"
+  no_match:
+    - "  config.active_record.whiny_nils = true"
+
+RESCUE_ACTION:
+  match:
+    - "  def rescue_action(exception)"
+  no_match:
+    - "  rescue_from StandardError do |e|"
+
+OBSERVERS:
+  match:
+    - "class UserObserver < ActiveRecord::Observer"
+    - "  config.active_record.observers = :user_observer"
+  no_match:
+    - "class UserPolicy"
+
+SWEEPERS:
+  match:
+    - "class ProductSweeper < ActionController::Caching::Sweeper"
+  no_match:
+    - "class ProductObserver < ActiveRecord::Observer"
+
+ACTION_CACHING:
+  match:
+    - "  caches_action :index"
+    - "  caches_page :show"
+  no_match:
+    - "  fragment_cache_key 'products'"
+
+ACTIVE_RESOURCE:
+  match:
+    - "class Product < ActiveResource::Base"
+  no_match:
+    - "class Product < ApplicationRecord"
+
+CACHE_KEY_FORMAT:
+  match:
+    - "self.cache_timestamp_format = :number"
+    - "  def cache_key; \"#{id}-#{updated_at}\"; end"
+  no_match:
+    - "  def display_name; name; end"
+
+BUFFERED_LOGGER:
+  match:
+    - "config.logger = ActiveSupport::BufferedLogger.new(log_path)"
+  no_match:
+    - "config.logger = ActiveSupport::Logger.new(log_path)"
+
+ASSETS_COMPRESS:
+  match:
+    - "  config.assets.compress = true"
+  no_match:
+    - "  config.assets.js_compressor = :uglifier"
+
+CONFIG_ROUTES_PATH:
+  match:
+    - "  config.paths[\"config/routes\"].concat %w(lib/custom_routes)"
+  no_match:
+    # exclude: routes.rb — a comment/reference to routes.rb on the same line
+    # suppresses the match even though "config/routes" is present too
+    - "  config.paths[\"config/routes\"].concat(Dir[Rails.root.join('config/routes.rb')])"
+
+ASSIGN_ATTRIBUTES_OPTIONS:
+  match:
+    - "  obj.assign_attributes(params, as: :admin)"
+  no_match:
+    - "  obj.assign_attributes(params)"
+
+RUN_VALIDATION_CALLBACKS:
+  match:
+    - "  _run_validation_callbacks"
+  no_match:
+    - "  run_callbacks(:validation)"
+
+SELECT_DISTINCT_PLUCK:
+  match:
+    - "User.select('distinct email').pluck(:email)"
+  no_match:
+    - "User.distinct.pluck(:email)"
+
+IMMUTABLE_RELATION:
+  match:
+    - "User.where(active: true).count('distinct email')"
+  no_match:
+    - "User.distinct.count"
+
+FIXTURE_DATES:
+  match:
+    - "created_at: <%= 3.days.ago %>"
+  no_match:
+    - "created_at: <%= 3.days.ago.to_s(:db) %>"
+
+UPDATE_ALL_TWO_ARG:
+  match:
+    - "User.update_all(\"active = false\", [\"id = ?\", 1])"
+  no_match:
+    - "User.where(id: 1).update_all(active: false)"
+
+OLD_FINDER:
+  match:
+    - "User.find(:first, conditions: { active: true })"
+  no_match:
+    - "User.where(active: true).first"
+
+REQUEST_ENV_MERGE:
+  match:
+    - "request.env.merge!('HTTP_AUTHORIZATION' => token)"
+  no_match:
+    - "request.headers.merge!('HTTP_AUTHORIZATION' => token)"


### PR DESCRIPTION
## Why

PR #110 seeded fixture-test coverage for one pattern (`SCOPE_WITHOUT_LAMBDA`) as a worked template, with the rest of `rails-40-patterns.yml` left uncovered.

## What this adds

- `match`/`no_match` expectations for the remaining 34 patterns in `rails-upgrade/detection-scripts/patterns/rails-40-patterns.expectations.yml`.
- `VENDOR_PLUGINS` stays uncovered on purpose: its `pattern` is `""` (path-only detection via `search_paths`), so `flagged?` always returns false and no line could ever pass a `match` assertion.

## Verification

- `bin/test-patterns rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml` -> 77 assertions, 35/36 patterns covered
- `bin/test-patterns --self-test` -> 5/5
- `bin/validate-patterns` + `--self-test` -> green