### PR TITLE
Add read_encrypted_secrets and to_time_preserves_timezone patterns to rails-80

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml
@@ -130,6 +130,27 @@ upgrade_findings:
       fix: "Use the schema_cache_path / cache_dump_filename API directly, or rely on the new ActiveRecord::Base.schema_cache_ignored_tables / connection_pool.schema_reflection knobs depending on the use case"
       variable_name: "ENV_SCHEMA_CACHE"
 
+    - name: "read_encrypted_secrets config"
+      kind: "deprecation"
+      pattern: "read_encrypted_secrets"
+      exclude: ""
+      search_paths:
+        - "config/environments/"
+        - "config/application.rb"
+      explanation: "config.read_encrypted_secrets drives the legacy encrypted-secrets feature (config/secrets.yml.enc), which was superseded by credentials and removed alongside config/secrets.yml in Rails 7.2. On 7.1/7.2 the setter emits `DEPRECATION WARNING: 'config.read_encrypted_secrets=' is deprecated and will be removed in Rails 8.0` at boot. On 8.0 the setter still exists as a silent no-op (no warning, no error), so the line is dead config either way — most visibly it noisily pollutes the 7.2 boot/precompile logs during the 7.2 → 8.0 hop"
+      fix: "Delete the `config.read_encrypted_secrets = true` line (and its comment block) from config/environments/production.rb. Safe to remove on both 7.2 and 8.0; no dual-boot branch needed. If the app genuinely stored secrets in config/secrets.yml.enc, migrate them to credentials (`rails credentials:edit`) first"
+      variable_name: "READ_ENCRYPTED_SECRETS"
+
+    - name: "to_time_preserves_timezone default (load_defaults below 8.1)"
+      kind: "deprecation"
+      pattern: "load_defaults\\s+(?:[4-7]\\.\\d+|8\\.0)\\b"
+      exclude: ""
+      search_paths:
+        - "config/application.rb"
+      explanation: "Under `config.load_defaults` below 8.1, ActiveSupport's `to_time_preserves_timezone` is not yet set to `:zone`, so Rails 8.0 emits `DEPRECATION WARNING: to_time will always preserve the full timezone rather than offset of the receiver in Rails 8.1` at boot (activesupport/CHANGELOG.md 8.1: to_time preserves the full timezone). The warning fires by default on every app that hasn't opted in — an explicit `to_time_preserves_timezone = :zone` is absent, so it can't be grepped for directly; the load_defaults value below 8.1 is the proxy signal"
+      fix: "Add `config.active_support.to_time_preserves_timezone = :zone` in config/application.rb (after `load_defaults`). Valid on both 7.2 and 8.0, so set it unconditionally during the dual boot — no NextRails.next? branch needed. This is the 8.1 default; setting it early makes `to_time` keep the full zone instead of a bare UTC offset and silences the warning"
+      variable_name: "TO_TIME_PRESERVES_TIMEZONE"
+
     - name: "Routes drawn with multiple paths"
       kind: "deprecation"
       pattern: "^\\s*(get|post|put|patch|delete|match)\\s+\\["


### PR DESCRIPTION
## What

Adds two `rails-80-patterns.yml` detections for deprecations that surface during a real Rails 7.2 -> 8.0 hop but weren't previously covered. Both `kind: deprecation`, both in `medium_priority`.

### `READ_ENCRYPTED_SECRETS`
- Pattern: `read_encrypted_secrets`
- Paths: `config/environments/`, `config/application.rb`
- `config.read_encrypted_secrets` drives the legacy encrypted-secrets feature (`config/secrets.yml.enc`), superseded by credentials and removed alongside `config/secrets.yml` in 7.2.
- Behavior confirmed empirically: **warns on 7.1/7.2** (`'config.read_encrypted_secrets=' is deprecated and will be removed in Rails 8.0`), but on **8.0.5 the setter still exists as a silent no-op** (no warning, no error). It is dead config either way; most visibly it pollutes the 7.2 boot/precompile logs during the hop. Fix is to delete the line.

### `TO_TIME_PRESERVES_TIMEZONE`
- Pattern: `load_defaults\s+(?:[4-7]\.\d+|8\.0)\b`
- Path: `config/application.rb`
- Under `load_defaults` below 8.1, ActiveSupport hasn't opted into the 8.1 `to_time` behavior, so 8.0 warns at boot (`to_time will always preserve the full timezone rather than offset ... in Rails 8.1`).
- The opt-in (`to_time_preserves_timezone = :zone`) is **absent by definition** when the warning fires, so it can't be grepped directly. The pattern proxies on a `load_defaults` value below 8.1. Regex correctly excludes `8.1`.
- Fix sets `config.active_support.to_time_preserves_timezone = :zone`, verified accepted on both 7.2.3.1 and 8.0.5 (set unconditionally, no dual-boot branch).

## Origin

Both surfaced during an actual 7.2 -> 8.0 dual-boot hop on a downstream app (`read_encrypted_secrets` in a Heroku production precompile log; `to_time` at test-suite boot). Fixes applied there boot both Gemfiles clean with zero deprecation warnings.

## Verification

`bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-80-patterns.yml` -> `OK`. Regex spot-checks: `load_defaults 7.1/8.0/6.0` match, `8.1` does not; `read_encrypted_secrets = true` matches.