### PR TITLE
Add Rails 7.0 open redirect protection detection

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-70-patterns.expectations.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-70-patterns.expectations.yml
@@ -1,0 +1,38 @@
+# Fixture expectations for rails-70-patterns.yml.
+#
+# Keyed by variable_name (matching the entries in rails-70-patterns.yml). For
+# each pattern you cover, list:
+#   match     - lines the pattern MUST flag (the real breaking-change shapes)
+#   no_match  - lines it MUST NOT flag (safe code + known false-positive traps)
+#
+# A line is "flagged" when the entry's `pattern` regex matches it AND the
+# entry's `exclude` regex (when present) does not: a per-line grep + grep -v.
+#
+# Run with:
+#   bin/test-patterns rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
+#
+# Only OPEN_REDIRECT_PROTECTION is covered so far; the other patterns in this
+# file predate the expectations tooling. Add entries as they are revisited.
+
+OPEN_REDIRECT_PROTECTION:
+  match:
+    # dynamic destination straight from user input, the classic open redirect
+    - "    redirect_to params[:return_to]"
+    - "    redirect_back_or_to session[:forward_url]"
+    # redirecting to the referer, the common replacement for redirect_to :back
+    - "    redirect_to request.referer"
+    # literal external URL, both quote styles
+    - "    redirect_to \"https://example.com\""
+    - "    redirect_to 'http://example.com/callback'"
+    # interpolated destination built from a host
+    - "    redirect_to \"#{other_host}/path\""
+  no_match:
+    # internal path/url helpers and records are unaffected, must not flag
+    - "    redirect_to root_path"
+    - "    redirect_to @user, notice: \"Saved\""
+    - "    redirect_to edit_post_path(@post)"
+    # params nested inside a path helper is a safe internal redirect, not the
+    # dangerous `redirect_to params[...]` shape
+    - "    redirect_to user_path(params[:id])"
+    # already opted in, the exclude regex must suppress it
+    - "    redirect_to \"https://example.com\", allow_other_host: true"

--- a/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml
@@ -126,6 +126,18 @@ upgrade_findings:
       fix: "Remove rails-ujs. Use Turbo for remote forms and Stimulus for JavaScript."
       variable_name: "RAILS_UJS"
 
+    - name: "redirect_to open redirect protection"
+      kind: "breaking"
+      pattern: "redirect_(to|back_or_to)\\s+(params\\[|session\\[|request\\.refer|[\"'][^\"']*(https?://|#\\{))"
+      exclude: "allow_other_host"
+      search_paths:
+        - "app/controllers/"
+        - "app/"
+        - "lib/"
+      explanation: "load_defaults 7.0 sets config.action_controller.raise_on_open_redirects = true. With it on, redirect_to and redirect_back_or_to to a host different from the current one raise ActionController::Redirecting::UnsafeRedirectError instead of redirecting. This is not a deprecation and there is no warning phase; it is gated by load_defaults 7.0, so apps only see it once they bump load_defaults to 7.0 (which is why it often surfaces during a later hop). Redirects to dynamic or external destinations (params, session, request.referer, or a literal/interpolated URL) are the ones that break; redirects to path helpers and model records are unaffected"
+      fix: "For each intentional external redirect, pass allow_other_host: true, e.g. redirect_to \"https://example.com\", allow_other_host: true. Never pass allow_other_host: true on a destination built from untrusted input (params, session, request.referer) without validating it against an allowlist first, or the open-redirect protection is defeated. If a redirect target is internal, rewrite it as a path/url helper so it passes without the flag"
+      variable_name: "OPEN_REDIRECT_PROTECTION"
+
     - name: "to_s(:format) deprecation"
       kind: "deprecation"
       pattern: "\\.to_s\\(:"

--- a/rails-upgrade/version-guides/upgrade-6.1-to-7.0.md
+++ b/rails-upgrade/version-guides/upgrade-6.1-to-7.0.md
@@ -288,6 +288,44 @@ Date.today.to_fs(:short)
 
 ---
 
+#### 10. redirect_to Open Redirect Protection
+
+**What Changed:**
+`load_defaults 7.0` sets `config.action_controller.raise_on_open_redirects = true`. With it on, `redirect_to` and `redirect_back_or_to` to a host different from the current one raise `ActionController::Redirecting::UnsafeRedirectError` instead of redirecting. This is not a deprecation, there is no warning phase, and it is gated by `load_defaults 7.0`, so an app only sees it once `load_defaults` reaches 7.0, which is often a later hop than the Rails 7.0 bump itself. Internal path/url helpers and model records are unaffected; only dynamic or external destinations break.
+
+**Detection Pattern:**
+```ruby
+redirect_to params[:return_to]
+redirect_back_or_to session[:forward_url]
+redirect_to request.referer
+redirect_to "https://example.com"
+```
+
+**Fix:**
+```ruby
+# BEFORE (raises UnsafeRedirectError under load_defaults 7.0)
+redirect_to "https://example.com"
+
+# AFTER: allow the external host explicitly
+redirect_to "https://example.com", allow_other_host: true
+```
+
+For destinations built from untrusted input, validate against an allowlist before allowing the external host. Passing `allow_other_host: true` on a raw `params`/`session`/`request.referer` value defeats the protection:
+
+```ruby
+# BEFORE (open redirect vulnerability if left unchecked)
+redirect_to params[:return_to]
+
+# AFTER: keep it internal, or validate before allowing other hosts
+redirect_to params[:return_to], allow_other_host: false
+# or rewrite an internal target as a path helper so no flag is needed
+redirect_to safe_path_for(params[:return_to])
+```
+
+If you are not ready to audit every call site at this hop, you can keep the old behavior by leaving `config.action_controller.raise_on_open_redirects = false` in `config/application.rb`, then adopt it later. See the `rails-load-defaults` skill for the incremental `load_defaults` walkthrough.
+
+---
+
 ## Migration Steps
 
 ### Phase 1: Preparation


### PR DESCRIPTION
## Summary

Adds coverage for Rails 7.0's `redirect_to` / `redirect_back_or_to` open redirect protection, which was missing from the `rails-upgrade` skill.

`load_defaults 7.0` sets `config.action_controller.raise_on_open_redirects = true`. With it on, redirecting to a host different from the current one raises `ActionController::Redirecting::UnsafeRedirectError` unless the call passes `allow_other_host: true`. This is not a deprecation and has no warning phase. It landed in Rails 7.0 ([commit `5e93cff835`](https://github.com/rails/rails/commit/5e93cff83599833380b4cb3d99c020b5efc7dd96), first shipped [`v7.0.0`](https://github.com/rails/rails/releases/tag/v7.0.0)) and is gated by `load_defaults`, so apps often only hit it on a later hop, once `load_defaults` reaches 7.0.

The `rails-load-defaults` skill already documents the `raise_on_open_redirects` default flip (`configs/7_0.yml`), but the `rails-upgrade` detection patterns and the 6.1 → 7.0 version guide had no entry to surface the affected call sites during an upgrade scan.

## Changes

- **`rails-70-patterns.yml`**: new `OPEN_REDIRECT_PROTECTION` pattern (🟡 MEDIUM, `kind: breaking`). Flags `redirect_to` / `redirect_back_or_to` to dynamic or external destinations (`params[...]`, `session[...]`, `request.referer`, literal or interpolated URLs) and excludes calls that already pass `allow_other_host`. Anchored right after the redirect call so `redirect_to user_path(params[:id])` and other internal helpers do not false-positive.
- **`rails-70-patterns.expectations.yml`**: new fixture file covering the pattern with 6 `match` and 5 `no_match` lines (external URLs in both quote styles, interpolation, referer, and the internal-helper / already-opted-in traps).


## Priority / kind rationale

- **MEDIUM**: the upgrade completes and the test suite boots without it, but a noticeable class of apps (any doing external or referer-based redirects) hits a runtime `UnsafeRedirectError`.
- **breaking**: it raises, not warns.

## Test plan

- [x] `bin/validate-patterns rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml` — clean
- [x] `bin/test-patterns rails-upgrade/detection-scripts/patterns/rails-70-patterns.yml` — 11 assertions pass
- [x] `bin/validate-patterns` + `--self-test` — clean
- [x] `bin/test-patterns` + `--self-test` — clean

## Source

- [`actionpack/lib/action_controller/metal/redirecting.rb`](https://github.com/rails/rails/blob/v7.0.0/actionpack/lib/action_controller/metal/redirecting.rb) (`v7.0.0`): `UnsafeRedirectError`, `raise_on_open_redirects` mattr (default `false`), `allow_other_host` handling.
- [`railties/lib/rails/application/configuration.rb`](https://github.com/rails/rails/blob/v7.0.0/railties/lib/rails/application/configuration.rb) (`v7.0.0`): `load_defaults 7.0` sets `raise_on_open_redirects = true`.
- Introducing commit: [`5e93cff8`](https://github.com/rails/rails/commit/5e93cff83599833380b4cb3d99c020b5efc7dd96) "Raise error on unpermitted open redirects", first shipped in [`v7.0.0`](https://github.com/rails/rails/releases/tag/v7.0.0).
- [Official Rails 7.0 upgrade guide](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html), open redirect protection.
