### PR TITLE
Harden scope/default_scope detection across the 4.x hops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,11 @@ Priority is about **urgency during an upgrade**, not editorial weight.
 
 **Judge `kind` at the target hop, not the API's historical timeline.** Each `rails-XY-patterns.yml` file is a statement *about that hop* — what changes when the user upgrades INTO that version. A removal that was first deprecated in an earlier Rails minor is `breaking` in the file for the version where it actually raises, not `deprecation` because of its history. The same API can legitimately be `deprecation` in `rails-31-patterns.yml` and `breaking` in `rails-40-patterns.yml`. Apply the rule to all four kinds: `kind` reflects what the change *is at this hop*, not what it *was* earlier or *will become* later.
 
-Concrete example: `SCOPE_WITHOUT_LAMBDA` was deprecated in Rails 3.1 and raises in 4.0 — it is `breaking` in `rails-40-patterns.yml`.
+Concrete example: `SCOPE_WITHOUT_LAMBDA`. Rails 3.2 accepts a non-callable scope body and merges it into the current scope; 4.0 warns and hands the stored relation back verbatim, silently dropping the association or chained scope; 4.1 raises `NoMethodError` at call time; 4.2 raises `ArgumentError` at class load. It is `breaking` in `rails-40-patterns.yml`, `rails-41-patterns.yml`, and `rails-42-patterns.yml` — see the next rule for why the 4.0 entry is not a `deprecation`.
+
+**A deprecation that changes query results is `breaking`.** Rule 2 below ("does Rails emit a deprecation warning?") assumes the deprecated code still *behaves correctly* at this hop — the usual case, where the warning is the only symptom and the real break is one version away. When the deprecated form instead changes what the database returns — dropped conditions, wrong rows, wrong SQL — classify it `breaking` at the hop where the behavior changes, whatever Rails prints. The deciding question is "can a green test suite and a clean boot hide this?", not "does Rails warn?". Deprecations whose only symptom is the warning stay `deprecation`, even at HIGH priority.
+
+`SCOPE_WITHOUT_LAMBDA` at 4.0 is the canonical case. Rails only warns, but `owner.things.active` silently queries the entire table instead of the owner's rows. That shipped to production in a real 3.2 → 4.0 upgrade and took a page down with an unbounded read; dev and CI held too little data for the query to be slow, so nothing failed before production. Do not reclassify it to `deprecation` on the strength of the warning — the pattern entries carry inline comments saying so.
 
 The four values:
 

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.expectations.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.expectations.yml
@@ -41,18 +41,54 @@ REQUIRE_STRONG_PARAMS:
     - "require 'strong_password'"
 
 SCOPE_WITHOUT_LAMBDA:
-  # Pattern: "scope\\s+:\\w+\\s*,\\s*where"
-  # Rails 4.0 requires every scope to wrap its query in a callable (lambda).
+  # Pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*\\S"
+  # Exclude:  "scope\\s+:\\w+\\s*,\\s*\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new)"
+  #
+  # Any non-callable body is wrong on 4.0, not just where(): the body is stored
+  # at class-definition time and handed back verbatim, discarding the
+  # association or scope it was chained onto. So the match list covers every
+  # bare-relation shape, and the exclusion is anchored to the body position
+  # (immediately after the scope name and comma) so a `proc` / `lambda`
+  # substring elsewhere on the line cannot suppress a real finding.
   match:
-    # bare where() right after the scope name — the breaking form
+    # bare where() right after the scope name — the classic form
     - "  scope :active, where(active: true)"
     # extra whitespace around the name and comma must still flag
     - "  scope :recent , where('created_at > ?', 1.week.ago)"
+    # order / joins / includes / select / limit / group bodies are equally non-callable
+    - "  scope :ordered, order(:position)"
+    - "  scope :with_author, joins(:author)"
+    - "  scope :eager, includes(:comments)"
+    - "  scope :ids_only, select(:id)"
+    - "  scope :top, limit(10)"
+    - "  scope :per_author, group(:author_id)"
+    # a relation built off another class is still a stored relation
+    - "  scope :published, Post.where(published: true)"
+    # a hash of finder options does not respond to #call either
+    - "  scope :legacy, conditions: { active: true }, order: 'id'"
+    # an argument named proc_* / lambda_* must not satisfy the anchored
+    # exclusion — this is a real finding
+    - "  scope :queued, where(proc_id: 3)"
   no_match:
     # already wrapped in a stabby lambda — the correct Rails 4 form
     - "  scope :active, -> { where(active: true) }"
     # wrapped in an explicit lambda — also correct, must not flag
     - "  scope :active, lambda { where(active: true) }"
+    # parameterized lambda
+    - "  scope :by_state, ->(state) { where(state: state) }"
+    # proc / Proc.new bodies respond to #call, so 4.0 handles them correctly
+    - "  scope :active, proc { where(active: true) }"
+    - "  scope :active, Proc.new { where(active: true) }"
+    # body on a continuation line: nothing follows the comma, so this line is
+    # not evidence either way and must not be flagged
+    - "  scope :active,"
+    # class method definition, not a scope declaration
+    - "  def self.active"
+    # a callable wrapped in parens is still callable — real shape found in the
+    # wild: scope :lookup, (proc { |s| where(...) })
+    - "  scope :lookup, (proc { |s| where(name: s) })"
+    - "  scope :recent, ( lambda { where('id > 0') } )"
+    - "  scope :ordered, (-> { order(:position) })"
 
 CLASS_SCOPED:
   # Pattern: "\\bscoped\\b"
@@ -79,11 +115,42 @@ CLASS_SCOPED:
     - "  def user_scoped"
 
 DEFAULT_SCOPE_WITHOUT_BLOCK:
+  # Pattern: "^\\s*default_scope\\b\\s*\\S"
+  # Exclude:  "default_scope\\b\\s*(do\\b|\\{|\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new))"
+  #
+  # Any non-block body is wrong, not just where() / order(): the argument has to
+  # respond to #call. The exclusion covers every callable form — a { } or do
+  # block, a stabby or explicit lambda, a proc, and any of those wrapped in
+  # parens.
   match:
-    - "  default_scope where(active: true)"
-    - "  default_scope :order => 'created_at'"
+    - "  default_scope where(deleted_at: nil)"
+    - "  default_scope order('created_at ASC')"
+    - "  default_scope :order => 'created_at ASC'"
+    # any other bare relation is equally non-callable
+    - "  default_scope joins(:account)"
+    - "  default_scope select(:id, :name)"
+    - "  default_scope Post.where(published: true)"
+    # a hash of finder options does not respond to #call either
+    - "  default_scope conditions: { active: true }"
+    # method-call form, no space before the paren
+    - "  default_scope(where(deleted_at: nil))"
   no_match:
-    - "  default_scope { where(active: true) }"
+    # block form — correct on 3.2 through current
+    - "  default_scope { where(deleted_at: nil) }"
+    # do/end block is equally callable
+    - "  default_scope do"
+    # explicit callables, bare and parenthesised
+    - "  default_scope -> { where(deleted_at: nil) }"
+    - "  default_scope lambda { where(deleted_at: nil) }"
+    - "  default_scope (proc { where(deleted_at: nil) })"
+    # overriding the method itself, not calling it
+    - "  def self.default_scope"
+    # commented out
+    - "  # default_scope where(deleted_at: nil)"
+    # an identifier that merely starts with "default_scope" — the \b guard.
+    # Found in the wild: a `default_scoper` helper call in a controller concern
+    - "          default_scoper"
+    - "  default_scoper.where(active: true)"
 
 ASSOCIATION_CONDITIONS:
   match:
@@ -458,3 +525,25 @@ RACK_LOCK_MIDDLEWARE:
     - '    config.middleware.use Rack::Lock'
     # commented-out line is inert
     - '    # config.middleware.insert_before Rack::Lock'
+
+SCOPE_BODY_CONTINUATION:
+  # Pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*$"
+  #
+  # Deliberately matches the declaration line alone, with nothing after the
+  # comma. SCOPE_WITHOUT_LAMBDA is line-oriented and cannot see a body that
+  # starts on the next line, so this flags the declaration for a human to read
+  # the continuation rather than dropping it. Both callable and non-callable
+  # continuations match — that is the point; the reviewer resolves which.
+  match:
+    - "  scope :with_likes_without_select,"
+    - "    scope :has_public_experience,"
+    - "  scope :for_acknowledgement,   "
+  no_match:
+    # body present on the same line — SCOPE_WITHOUT_LAMBDA owns these
+    - "  scope :active, where(active: true)"
+    - "  scope :active, -> { where(active: true) }"
+    # a trailing comma inside a body, not a bare declaration
+    - "  scope :legacy, conditions: { active: true },"
+    # not a scope declaration at all
+    - "  def self.active"
+    - "  # scope :active,"

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -37,24 +37,54 @@ upgrade_findings:
       fix: "Remove require 'strong_parameters' calls entirely"
       variable_name: "REQUIRE_STRONG_PARAMS"
 
+    # kind: breaking is deliberate. Rails 4.0 emits a deprecation warning rather
+    # than raising, but the runtime behaviour is silently wrong results (see the
+    # explanation below), which is a data-level failure at THIS hop, not a
+    # warning to schedule later. Verified against activerecord-4.0.13
+    # lib/active_record/scoping/named.rb:161-170 — see version-guides/upgrade-3.2-to-4.0.md
+    # section 3a for the source diff and the SQL evidence. Do not reclassify to
+    # deprecation on the strength of the warning alone.
     - name: "Scope without lambda"
       kind: "breaking"
-      pattern: "scope\\s+:\\w+\\s*,\\s*where"
-      exclude: ""
+      pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*\\S"
+      exclude: "scope\\s+:\\w+\\s*,\\s*\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new)"
       search_paths:
         - "app/models/"
-      explanation: "Rails 4.0 requires all scopes to use a lambda"
-      fix: "Change scope :name, where(...) to scope :name, -> { where(...) }"
+      explanation: "Rails 4.0 only warns on a non-callable scope body, but it SILENTLY RETURNS WRONG RESULTS. 3.2 merged the stored relation into the current scope (scoped.merge(options)); 4.0 returns the stored relation verbatim, discarding whatever it was chained onto. incident.issues.active drops the incident_id condition and queries the whole table; Model.where(x).active drops where(x). No error, no warning at call time — just a full-table read and wrong rows. It raises NoMethodError in 4.1 and ArgumentError at class load in 4.2, so the fix is not deferrable. Any body counts, not just where(): order, joins, includes, select, limit, group, and a hash of finder options are all non-callable"
+      fix: "Wrap every scope body in a lambda: scope :name, where(...) becomes scope :name, -> { where(...) }. Treat this as mandatory, not stylistic. The lambda form is valid on Rails 3.2 as well, so it is safe to apply before the bump and under dual boot. Grep for every scope with a non-callable body (any bare method call, not only where), and check any that are called through an association or chained onto another scope first — those are the ones already returning wrong data"
       variable_name: "SCOPE_WITHOUT_LAMBDA"
 
-    - name: "default_scope without block"
+    # SCOPE_WITHOUT_LAMBDA is line-oriented and needs the body on the same line
+    # as the declaration, so it cannot see `scope :name,` followed by the body
+    # on the next line. That form is common in real code once the body is long
+    # enough to wrap. Measured on one Packwerk app: 22 of its 25 non-callable
+    # scopes were single-line and flagged, and the 3 it missed were all this
+    # shape — two of which were live bugs. This pattern flags the declaration so
+    # a human reads the next line, rather than dropping it silently.
+    - name: "Scope body on a continuation line (manual review)"
       kind: "breaking"
-      pattern: "default_scope\\s+(where|order|:order)"
+      pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*$"
       exclude: ""
       search_paths:
         - "app/models/"
-      explanation: "Rails 4.0 requires default_scope to use a block"
-      fix: "Change default_scope where(...) to default_scope { where(...) }"
+      explanation: "The scope's body starts on the following line, so a single-line pattern cannot tell whether it is callable. Read the next non-blank line: if it opens with ->, lambda, proc or Proc.new the scope is fine; anything else (joins, where, order, includes, a relation on another class) is a non-callable body and carries the full SCOPE_WITHOUT_LAMBDA problem — silently wrong rows on 4.0, NoMethodError on 4.1, a class-load ArgumentError on 4.2"
+      fix: "Inspect the continuation line and wrap the body in a lambda if it is not already callable: scope :with_author,\\n  joins(:author) becomes scope :with_author, -> { joins(:author) }. Report each occurrence as reviewed, not as fixed-by-pattern"
+      variable_name: "SCOPE_BODY_CONTINUATION"
+
+    # Unlike `scope`, a non-block default_scope still behaves CORRECTLY on 4.0:
+    # build_default_scope merges it (activerecord-4.0.13
+    # lib/active_record/scoping/default.rb). It raises at class load in 4.1.
+    # Kept as breaking so it is fixed in the same pass as the scope bodies —
+    # the two live on the same lines of the same models, and splitting them
+    # across hops means touching every model twice.
+    - name: "default_scope without block"
+      kind: "breaking"
+      pattern: "^\\s*default_scope\\b\\s*\\S"
+      exclude: "default_scope\\b\\s*(do\\b|\\{|\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new))"
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 4.0 warns on default_scope without a block but still applies it correctly (build_default_scope merges a Relation argument). Rails 4.1 raises ArgumentError, 'Support for calling #default_scope without a block is removed', at class-definition time — a boot failure at the next hop"
+      fix: "Change default_scope where(...) to default_scope { where(...) }. The block form works on Rails 3.2 as well"
       variable_name: "DEFAULT_SCOPE_WITHOUT_BLOCK"
 
     - name: "Association :conditions option"

--- a/rails-upgrade/detection-scripts/patterns/rails-41-patterns.expectations.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-41-patterns.expectations.yml
@@ -1,0 +1,104 @@
+# Fixture expectations for rails-41-patterns.yml.
+#
+# Coverage is partial: only the patterns listed here are asserted. Patterns
+# without an entry are not tested (bin/test-patterns only checks the keys it
+# finds), so add entries as patterns are touched. See
+# rails-40-patterns.expectations.yml for the fully-documented worked example.
+#
+# Run with:
+#   bin/test-patterns rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
+
+SCOPE_WITHOUT_LAMBDA:
+  # Pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*\\S"
+  # Exclude:  "scope\\s+:\\w+\\s*,\\s*\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new)"
+  #
+  # Same regex as the 4.0 file — the difference is the consequence, not the
+  # shape: 4.0 warns and silently drops the surrounding scope, 4.1 raises
+  # NoMethodError when the scope is called.
+  match:
+    - "  scope :active, where(active: true)"
+    - "  scope :ordered, order(:position)"
+    - "  scope :published, Post.where(published: true)"
+    - "  scope :legacy, conditions: { active: true }, order: 'id'"
+  no_match:
+    - "  scope :active, -> { where(active: true) }"
+    - "  scope :by_state, ->(state) { where(state: state) }"
+    - "  scope :active, lambda { where(active: true) }"
+    - "  scope :active, proc { where(active: true) }"
+    - "  scope :active, Proc.new { where(active: true) }"
+    - "  def self.active"
+    # a callable wrapped in parens is still callable
+    - "  scope :lookup, (proc { |s| where(name: s) })"
+    - "  scope :ordered, (-> { order(:position) })"
+
+DEFAULT_SCOPE_WITHOUT_BLOCK:
+  # Pattern: "^\\s*default_scope\\b\\s*\\S"
+  # Exclude:  "default_scope\\b\\s*(do\\b|\\{|\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new))"
+  #
+  # Any non-block body is wrong, not just where() / order(): the argument has to
+  # respond to #call. The exclusion covers every callable form — a { } or do
+  # block, a stabby or explicit lambda, a proc, and any of those wrapped in
+  # parens.
+  # The non-block form raises ArgumentError at class-definition time on 4.1.
+  match:
+    - "  default_scope where(deleted_at: nil)"
+    - "  default_scope order('created_at ASC')"
+    - "  default_scope :order => 'created_at ASC'"
+    # any other bare relation is equally non-callable
+    - "  default_scope joins(:account)"
+    - "  default_scope select(:id, :name)"
+    - "  default_scope Post.where(published: true)"
+    # a hash of finder options does not respond to #call either
+    - "  default_scope conditions: { active: true }"
+    # method-call form, no space before the paren
+    - "  default_scope(where(deleted_at: nil))"
+  no_match:
+    # block form — correct on 3.2 through current
+    - "  default_scope { where(deleted_at: nil) }"
+    # do/end block is equally callable
+    - "  default_scope do"
+    # explicit callables, bare and parenthesised
+    - "  default_scope -> { where(deleted_at: nil) }"
+    - "  default_scope lambda { where(deleted_at: nil) }"
+    - "  default_scope (proc { where(deleted_at: nil) })"
+    # overriding the method itself, not calling it
+    - "  def self.default_scope"
+    # commented out
+    - "  # default_scope where(deleted_at: nil)"
+    # an identifier that merely starts with "default_scope" — the \b guard.
+    # Found in the wild: a `default_scoper` helper call in a controller concern
+    - "          default_scoper"
+    - "  default_scoper.where(active: true)"
+
+SCOPE_BODY_CONTINUATION:
+  # Pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*$"
+  # See the same block in rails-40-patterns.expectations.yml.
+  match:
+    - "  scope :with_likes_without_select,"
+    - "    scope :has_public_experience,"
+  no_match:
+    - "  scope :active, where(active: true)"
+    - "  scope :active, -> { where(active: true) }"
+    - "  scope :legacy, conditions: { active: true },"
+    - "  def self.active"
+    - "  # scope :active,"
+
+SCOPE_NAME_COLLISION:
+  # Pattern: "^\\s*scope\\s+:(none|all|first|last|take|find|count|sum|average|minimum|maximum|select|update|delete|destroy|create|new|group|order|limit|offset|distinct|ids|pluck)\\b"
+  #
+  # 4.1 raises at class-definition time when a scope name shadows a class
+  # method Active Record already defines. The \b matters: a name that merely
+  # starts with a reserved word (:ordered, :newest, :selected, :first_active)
+  # is not a collision and must not be flagged.
+  match:
+    - "  scope :none, -> { where('1=0') }"
+    - "  scope :all, -> { where(nil) }"
+    - "    scope :count, -> { group(:id) }"
+    - "  scope :select, -> { where(chosen: true) }"
+  no_match:
+    - "  scope :ordered, -> { order(:position) }"
+    - "  scope :newest, -> { order(created_at: :desc) }"
+    - "  scope :selected, -> { where(chosen: true) }"
+    - "  scope :first_active, -> { where(active: true) }"
+    - "  scope :nonexistent, -> { where(missing: true) }"
+    - "  def self.none"

--- a/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-41-patterns.yml
@@ -68,6 +68,57 @@ upgrade_findings:
       fix: "Audit each scope on models with default_scope. Use unscope(where: :col) or rewhere(col: value) where a scope is supposed to override the default"
       variable_name: "DEFAULT_SCOPE"
 
+    # The 4.0 hop only warned about these two (see rails-40-patterns.yml). If
+    # they survived that hop they stop working here, so re-check them even when
+    # the 4.0 report was cleared.
+    - name: "Scope without lambda"
+      kind: breaking
+      pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*\\S"
+      exclude: "scope\\s+:\\w+\\s*,\\s*\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new)"
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 4.1 dropped the 4.0 deprecation path for non-callable scope bodies and calls body.call unconditionally (activerecord-4.1 lib/active_record/scoping/named.rb). A stored Relation does not respond to #call, so the scope raises NoMethodError the first time it is called — lazily, at call time, not at boot, so a green boot proves nothing. On 4.0 the same code silently returned wrong rows instead of raising"
+      fix: "Wrap the body in a lambda: scope :name, -> { where(...) }. Valid on 3.2 and every later version, so it can be applied before the bump"
+      variable_name: "SCOPE_WITHOUT_LAMBDA"
+
+    - name: "default_scope without block"
+      kind: breaking
+      pattern: "^\\s*default_scope\\b\\s*\\S"
+      exclude: "default_scope\\b\\s*(do\\b|\\{|\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new))"
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 4.1 raises ArgumentError, 'Support for calling #default_scope without a block is removed', at class-definition time. Unlike the scope case this fails while the class loads, so it surfaces as a boot / eager-load failure rather than a runtime error"
+      fix: "Change default_scope where(...) to default_scope { where(...) }, or redefine self.default_scope"
+      variable_name: "DEFAULT_SCOPE_WITHOUT_BLOCK"
+
+    # See the same entry in rails-40-patterns.yml for why this exists: the
+    # single-line pattern above cannot see a body that starts on the next line.
+    - name: "Scope body on a continuation line (manual review)"
+      kind: breaking
+      pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*$"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+      explanation: "The scope's body starts on the following line, so a single-line pattern cannot tell whether it is callable. Read the next non-blank line: anything that does not open with ->, lambda, proc or Proc.new is a non-callable body, which raises NoMethodError the first time the scope is called on 4.1"
+      fix: "Inspect the continuation line and wrap the body in a lambda if it is not already callable. Report each occurrence as reviewed, not as fixed-by-pattern"
+      variable_name: "SCOPE_BODY_CONTINUATION"
+
+    # New in 4.1 and independent of whether the body is callable: `scope` now
+    # refuses a name that Active Record already defines as a class method.
+    # Verified against rails/rails 4-1-stable and 4-2-stable
+    # activerecord/lib/active_record/scoping/named.rb. 4.0's `scope` has no name
+    # check at all, and 3.2 only logged "Overwriting existing method", so a
+    # colliding scope can sit in a codebase for years before this hop.
+    - name: "Scope name collides with an Active Record class method"
+      kind: breaking
+      pattern: "^\\s*scope\\s+:(none|all|first|last|take|find|count|sum|average|minimum|maximum|select|update|delete|destroy|create|new|group|order|limit|offset|distinct|ids|pluck)\\b"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 4.1 added a guard to ActiveRecord::Scoping::Named#scope: `if dangerous_class_method?(name) ... raise ArgumentError, 'You tried to define a scope named \"x\" on the model \"Y\", but Active Record already defined a class method with the same name.'` This fires at class-definition time, so one colliding scope anywhere breaks boot or eager load. `scope :none` is the common one — Active Record defines `none` itself from 4.0 onward, and apps that hand-rolled a `none` scope on 3.2 (where it did not exist) are carrying a name that now collides"
+      fix: "Rename the scope, or delete it when Active Record's own method already does the job — a hand-rolled `scope :none, -> { where('1=0') }` is redundant from 4.0, since Model.none returns a NullRelation without touching the database. Rails' own check is authoritative; this pattern lists the common collisions and cannot know about class methods your own model defines"
+      variable_name: "SCOPE_NAME_COLLISION"
+
   medium_priority:
     - name: "MultiJSON usage"
       kind: breaking

--- a/rails-upgrade/detection-scripts/patterns/rails-42-patterns.expectations.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-42-patterns.expectations.yml
@@ -1,0 +1,99 @@
+# Fixture expectations for rails-42-patterns.yml.
+#
+# Coverage is partial: only the patterns listed here are asserted. Patterns
+# without an entry are not tested (bin/test-patterns only checks the keys it
+# finds), so add entries as patterns are touched. See
+# rails-40-patterns.expectations.yml for the fully-documented worked example.
+#
+# Run with:
+#   bin/test-patterns rails-upgrade/detection-scripts/patterns/rails-42-patterns.yml
+
+SCOPE_WITHOUT_LAMBDA:
+  # Pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*\\S"
+  # Exclude:  "scope\\s+:\\w+\\s*,\\s*\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new)"
+  #
+  # Same regex as the 4.0 and 4.1 files. On 4.2 the guard clause in
+  # ActiveRecord::Scoping::Named#scope raises ArgumentError while the class
+  # loads, so any finding here is a boot blocker.
+  match:
+    - "  scope :active, where(active: true)"
+    - "  scope :ordered, order(:position)"
+    - "  scope :published, Post.where(published: true)"
+    - "  scope :legacy, conditions: { active: true }, order: 'id'"
+  no_match:
+    - "  scope :active, -> { where(active: true) }"
+    - "  scope :by_state, ->(state) { where(state: state) }"
+    - "  scope :active, lambda { where(active: true) }"
+    - "  scope :active, proc { where(active: true) }"
+    - "  scope :active, Proc.new { where(active: true) }"
+    - "  def self.active"
+    # a callable wrapped in parens is still callable
+    - "  scope :lookup, (proc { |s| where(name: s) })"
+    - "  scope :ordered, (-> { order(:position) })"
+
+SCOPE_BODY_CONTINUATION:
+  # Pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*$"
+  # See the same block in rails-40-patterns.expectations.yml.
+  match:
+    - "  scope :with_likes_without_select,"
+    - "    scope :has_public_experience,"
+  no_match:
+    - "  scope :active, where(active: true)"
+    - "  scope :active, -> { where(active: true) }"
+    - "  scope :legacy, conditions: { active: true },"
+    - "  def self.active"
+    - "  # scope :active,"
+
+SCOPE_NAME_COLLISION:
+  # Pattern: "^\\s*scope\\s+:(none|all|first|last|take|find|count|sum|average|minimum|maximum|select|update|delete|destroy|create|new|group|order|limit|offset|distinct|ids|pluck)\\b"
+  # See the same block in rails-41-patterns.expectations.yml — the guard is
+  # unchanged in 4.2, and matters for an app hopping 4.0 -> 4.2 directly.
+  match:
+    - "  scope :none, -> { where('1=0') }"
+    - "  scope :all, -> { where(nil) }"
+    - "    scope :count, -> { group(:id) }"
+  no_match:
+    - "  scope :ordered, -> { order(:position) }"
+    - "  scope :newest, -> { order(created_at: :desc) }"
+    - "  scope :selected, -> { where(chosen: true) }"
+    - "  scope :first_active, -> { where(active: true) }"
+    - "  def self.none"
+
+DEFAULT_SCOPE_WITHOUT_BLOCK:
+  # Pattern: "^\\s*default_scope\\b\\s*\\S"
+  # Exclude:  "default_scope\\b\\s*(do\\b|\\{|\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new))"
+  #
+  # Any non-block body is wrong, not just where() / order(): the argument has to
+  # respond to #call. The exclusion covers every callable form — a { } or do
+  # block, a stabby or explicit lambda, a proc, and any of those wrapped in
+  # parens.
+  # Removed in 4.1, still removed in 4.2: ArgumentError at class-definition time.
+  match:
+    - "  default_scope where(deleted_at: nil)"
+    - "  default_scope order('created_at ASC')"
+    - "  default_scope :order => 'created_at ASC'"
+    # any other bare relation is equally non-callable
+    - "  default_scope joins(:account)"
+    - "  default_scope select(:id, :name)"
+    - "  default_scope Post.where(published: true)"
+    # a hash of finder options does not respond to #call either
+    - "  default_scope conditions: { active: true }"
+    # method-call form, no space before the paren
+    - "  default_scope(where(deleted_at: nil))"
+  no_match:
+    # block form — correct on 3.2 through current
+    - "  default_scope { where(deleted_at: nil) }"
+    # do/end block is equally callable
+    - "  default_scope do"
+    # explicit callables, bare and parenthesised
+    - "  default_scope -> { where(deleted_at: nil) }"
+    - "  default_scope lambda { where(deleted_at: nil) }"
+    - "  default_scope (proc { where(deleted_at: nil) })"
+    # overriding the method itself, not calling it
+    - "  def self.default_scope"
+    # commented out
+    - "  # default_scope where(deleted_at: nil)"
+    # an identifier that merely starts with "default_scope" — the \b guard.
+    # Found in the wild: a `default_scoper` helper call in a controller concern
+    - "          default_scoper"
+    - "  default_scoper.where(active: true)"

--- a/rails-upgrade/detection-scripts/patterns/rails-42-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-42-patterns.yml
@@ -77,6 +77,57 @@ upgrade_findings:
       fix: "Set config.active_job.queue_adapter = :sidekiq (or :resque, :delayed_job, :que, etc.) in config/application.rb or per-environment, and ensure the adapter gem is in the Gemfile. For dev/test without a backend, :inline or :async is acceptable"
       variable_name: "ACTIVE_JOB_ADAPTER"
 
+    # Third and final stop for the non-callable scope body: warned in 4.0,
+    # NoMethodError at call time in 4.1, and from 4.2 the class will not even
+    # load. See version-guides/upgrade-3.2-to-4.0.md section 3a for the
+    # per-version source evidence.
+    - name: "Scope without lambda"
+      kind: "breaking"
+      pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*\\S"
+      exclude: "scope\\s+:\\w+\\s*,\\s*\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new)"
+      search_paths:
+        - "app/models/"
+      explanation: "Rails 4.2 added a guard clause to ActiveRecord::Scoping::Named#scope: `unless body.respond_to?(:call) ... raise ArgumentError, 'The scope body needs to be callable.'`. This fires at class-definition time, so a single non-callable scope anywhere in the app breaks boot / eager load"
+      fix: "Wrap the body in a lambda: scope :name, -> { where(...) }"
+      variable_name: "SCOPE_WITHOUT_LAMBDA"
+
+    # Removed in 4.1 and still removed in 4.2. Repeated here for the app that
+    # hops 4.0 -> 4.2 directly and never reads the 4.1 guide.
+    - name: "default_scope without block"
+      kind: "breaking"
+      pattern: "^\\s*default_scope\\b\\s*\\S"
+      exclude: "default_scope\\b\\s*(do\\b|\\{|\\(?\\s*(->|lambda\\b|proc\\b|Proc\\.new))"
+      search_paths:
+        - "app/models/"
+      explanation: "Support for calling #default_scope without a block was removed in Rails 4.1 and is still absent in 4.2: it raises ArgumentError at class-definition time, so it fails boot / eager load rather than at query time"
+      fix: "Change default_scope where(...) to default_scope { where(...) }, or redefine self.default_scope"
+      variable_name: "DEFAULT_SCOPE_WITHOUT_BLOCK"
+
+    # See rails-40-patterns.yml for why this exists: the single-line pattern
+    # above cannot see a body that starts on the next line.
+    - name: "Scope body on a continuation line (manual review)"
+      kind: "breaking"
+      pattern: "^\\s*scope\\s+:\\w+\\s*,\\s*$"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+      explanation: "The scope's body starts on the following line, so a single-line pattern cannot tell whether it is callable. Read the next non-blank line: anything that does not open with ->, lambda, proc or Proc.new is a non-callable body, and from 4.2 that stops the class from loading at all"
+      fix: "Inspect the continuation line and wrap the body in a lambda if it is not already callable. Report each occurrence as reviewed, not as fixed-by-pattern"
+      variable_name: "SCOPE_BODY_CONTINUATION"
+
+    # The collision guard added in 4.1 is still present in 4.2, so an app
+    # hopping 4.0 -> 4.2 directly needs the same check. Verified against
+    # rails/rails 4-2-stable activerecord/lib/active_record/scoping/named.rb.
+    - name: "Scope name collides with an Active Record class method"
+      kind: "breaking"
+      pattern: "^\\s*scope\\s+:(none|all|first|last|take|find|count|sum|average|minimum|maximum|select|update|delete|destroy|create|new|group|order|limit|offset|distinct|ids|pluck)\\b"
+      exclude: ""
+      search_paths:
+        - "app/models/"
+      explanation: "ActiveRecord::Scoping::Named#scope raises ArgumentError, 'You tried to define a scope named \"x\" on the model \"Y\", but Active Record already defined a class method with the same name.', at class-definition time. Introduced in 4.1 and still present in 4.2, so an app skipping straight from 4.0 hits it here"
+      fix: "Rename the scope, or delete it when Active Record's own method already covers it. Rails' own check is authoritative; this pattern lists the common collisions and cannot know about class methods your own model defines"
+      variable_name: "SCOPE_NAME_COLLISION"
+
   medium_priority:
     - name: "find/exists? with possible AR object argument"
       kind: "deprecation"

--- a/rails-upgrade/version-guides/upgrade-3.2-to-4.0.md
+++ b/rails-upgrade/version-guides/upgrade-3.2-to-4.0.md
@@ -116,9 +116,13 @@ ActiveRecord scopes must use a lambda. Additionally, association options like `:
 
 ##### 3a. Scopes
 
+Wrapping a scope body in a lambda is **mandatory at this hop, not stylistic**. Rails 4.0 does not raise on the old form — it prints a deprecation warning and then **silently returns wrong rows**. Skipping this fix is the single most dangerous choice in a 3.2 → 4.0 upgrade, because nothing fails loudly: no exception, no warning at query time, just different SQL than the code asks for. Treat it as a hard break even though Rails only warns.
+
 **Detection Pattern:**
 ```ruby
 scope :active, where(active: true)
+scope :ordered, order(:position)          # any bare relation, not just where()
+scope :with_author, joins(:author)
 default_scope where(deleted_at: nil)
 default_scope :order => 'created_at ASC'
 ```
@@ -135,6 +139,98 @@ scope :active, -> { where(active: true) }
 default_scope { where(deleted_at: nil) }
 default_scope { order('created_at ASC') }
 ```
+
+Both `AFTER` forms are valid on Rails 3.2, so apply them before the bump and under dual boot.
+
+###### Why the old form breaks silently (Rails source)
+
+The eagerly-built relation is created once, at class-definition time, against the model class. What changed between versions is what `Model.scope_name` does with it.
+
+**Rails 3.2** — `activerecord-3.2.22/lib/active_record/scoping/named.rb`:
+
+```ruby
+scope_proc = lambda do |*args|
+  options = scope_options.respond_to?(:call) ? unscoped { scope_options.call(*args) } : scope_options
+  options = scoped.apply_finder_options(options) if options.is_a?(Hash)
+
+  relation = scoped.merge(options)   # <-- merged INTO the current scope
+  ...
+end
+```
+
+3.2 wraps even a non-callable body in a lambda and **merges it into `scoped`** at call time. Inside an association proxy, `scoped` is the association's relation, so the owner's condition survives. The stored relation is only ever a bag of conditions to merge.
+
+**Rails 4.0** — `activerecord-4.0.13/lib/active_record/scoping/named.rb:161-170`:
+
+```ruby
+singleton_class.send(:define_method, name) do |*args|
+  if body.respond_to?(:call)
+    scope = all.scoping { body.call(*args) }   # current scope preserved
+    scope = scope.extending(extension) if extension
+  else
+    scope = body                              # <-- returned verbatim
+  end
+
+  scope || all
+end
+```
+
+There is no `merge` and no `scoping` on the non-callable branch. Rails hands back the relation object built at class-definition time, which knows nothing about the receiver — so **everything to the left of the scope is discarded**. The lambda branch works because `all.scoping { }` installs the current scope before the body runs.
+
+Rails 4.0 flags this itself at `named.rb:150-159`:
+
+> Using #scope without passing a callable object is deprecated. [...] There are numerous gotchas in the former usage and it makes the implementation more complicated and buggy.
+
+This is one of those gotchas.
+
+###### The SQL, measured
+
+Given `has_many :issues` on `Incident` and `scope :active` on `Issue`, `incident.issues.active.to_sql` for `incident.id = 123`:
+
+```sql
+-- Rails 3.2, and Rails 4.0 with `scope :active, -> { where(deleted: nil) }`
+SELECT `issues`.* FROM `issues`
+WHERE `issues`.`incident_id` = 123 AND `issues`.`deleted` IS NULL
+
+-- Rails 4.0 with `scope :active, where(deleted: nil)`
+SELECT `issues`.* FROM `issues`
+WHERE `issues`.`deleted` IS NULL
+```
+
+The `incident_id` predicate is gone. Chaining class-level scopes loses the left-hand side the same way — `Issue.where(id: 5).active` drops `id = 5` and selects the whole table.
+
+Field report: this exact shape shipped to production in a 3.2 → 4.0 dual-boot upgrade. A page called `incident.issues.active` to decide whether a record was editable; on 4.0 that became an unbounded read of a multi-million-row table, the request never returned, and the failure surfaced as a 503 from the proxy after the worker died. Development and CI had too little data for the query to hurt, so it passed every pre-production gate. Wrong-but-survivable on a small database, fatal on a large one — which is why this cannot be deferred to a later hop.
+
+###### What each version does
+
+| Version | Non-callable `scope` body | Non-block `default_scope` | Scope name shadowing an AR class method |
+|---------|---------------------------|---------------------------|------------------------------------------|
+| 3.2 | Works. Merged into the current scope | Works | Allowed. Logs `Creating scope :x. Overwriting existing method` |
+| 4.0 | **Deprecation warning, silently wrong results.** Discards the association / chained scope | Deprecation warning, still applied correctly (`build_default_scope` merges it) | Allowed silently — `#scope` has no name check at all |
+| 4.1 | `NoMethodError: undefined method 'call'` — raised lazily on first call, not at boot | `ArgumentError: Support for calling #default_scope without a block is removed` at class load | `ArgumentError: You tried to define a scope named "x" on the model "Y", but Active Record already defined a class method with the same name.` at class load |
+| 4.2 | `ArgumentError: The scope body needs to be callable.` at class load (guard clause added to `#scope`) | Same as 4.1 | Same as 4.1 |
+
+Note the asymmetry: `default_scope` degrades honestly (deprecated but correct, then raises), while `scope` has a one-version window where it is quietly wrong. If you only have time for part of this section, do the `scope` half.
+
+The third column is a separate trap with a longer fuse, and `none` is the one that springs it. Active Record gained `Model.none` in 4.0, so a `scope :none` an app hand-rolled on 3.2 — where no such method existed — keeps working on 3.2 and 4.0, then refuses to load the class on 4.1. Delete those rather than renaming: the built-in returns a `NullRelation` without touching the database, which is what the hand-rolled `where('1=0')` was approximating.
+
+###### Auditing
+
+- Grep for **any** non-callable body, not just `where(...)`: `order`, `joins`, `includes`, `select`, `limit`, `group`, `uniq`, a relation built off another class (`Post.where(...)`), and a bare hash of finder options are all affected.
+- Fix them all, but triage by call site first: scopes reached **through an association** (`owner.things.scope_name`) or **chained onto another scope** are the ones already returning wrong data. A scope only ever called as `Model.scope_name` on its own produces the same SQL either way, which is why these survive so long unnoticed.
+- **Find the real model roots before grepping.** `app/models/` is an assumption, not a fact. Packwerk apps keep models in `packs/*/app/models/`, engine hosts in `engines/*/app/models/`, and some apps have no top-level `app/` at all — where a sweep of `app/models/` returns zero findings and reads as a clean bill of health. `Glob: "**/app/models/*.rb"` first, and say in the report which roots you searched.
+- **Catch the multi-line form.** A line-oriented grep for `scope :name, <body>` misses a body that wraps onto the next line:
+
+  ```ruby
+  scope :with_likes_without_select,
+    joins("LEFT OUTER JOIN likes ON ...")
+    .group("posts.id")
+  ```
+
+  Grep separately for a declaration with nothing after the comma (`^\s*scope\s+:\w+\s*,\s*$`) and read the following line. On one audited codebase 22 of 25 non-callable scopes were single-line and caught by the obvious grep; all 3 misses were this shape, and two of them were live bugs.
+- **Gems declare scopes on your models too.** `acts_as_commentable`, `acts_as_list`, `friendly_id` and friends inject scopes that carry the same defect and appear nowhere in your repo. Grep cannot see them; booting the app can — the deprecation warning names the `include` line in your model. Check whether a newer release of the gem already fixed it before patching around it.
+- Verify a fix with `to_sql` through the association, not in isolation: `owner.things.scope_name.to_sql` must still contain the foreign-key predicate.
+- To prove a whole codebase is clean rather than spot-checking, walk every `has_many` whose target class declares one of these scopes, generate `owner.assoc.scope_name.to_sql` under both the old and new boot, and diff. Any pair whose SQL differs is a regression; under dual boot this runs in one session against the same data.
 
 ##### 3b. Association `:conditions` hash → lambda with `where()`
 
@@ -833,7 +929,7 @@ bundle update rails
 ```
 
 ### Phase 3: Fix Breaking Changes
-1. Add lambda to all scopes
+1. Add lambda to **every** scope (mandatory — 4.0 only warns, then returns silently wrong rows; see Section 3a)
 2. **Migrate all association `:conditions`, `:order`, `:extend`, `:uniq` options to lambda syntax** (this is typically the highest-volume change)
 3. Rewrite `:finder_sql` associations as scopes or methods; remove `:readonly` options
 4. Update dynamic finders to where/find_by
@@ -890,6 +986,8 @@ Error → section lookup for the most common errors encountered during this upgr
 |-------|-----|
 | `ActiveModel::ForbiddenAttributesError` | Section 2 (Strong Parameters) — use `user_params` not `params[:user]` |
 | Scope returns wrong results or errors | Section 3a (Scopes) — add lambda |
+| Query through an association returns rows from the whole table | Section 3a (Scopes) — a non-callable scope body dropped the owner condition |
+| Unexplained slow query / timeout / 503 on a page that scopes an association | Section 3a (Scopes) — check for a full-table read from a non-lambda scope |
 | `Unknown key: :conditions` | Section 3b (Association conditions) — move to lambda |
 | `No route matches` | Section 5 (Routes) — add HTTP method |
 | `NoMethodError: undefined method 'rescue_action'` | Section 6 (rescue_action) — use `rescue_from` |

--- a/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
+++ b/rails-upgrade/version-guides/upgrade-4.0-to-4.1.md
@@ -244,6 +244,77 @@ See [this commit](https://github.com/rails/rails/commit/f950b2699f97749ef706c693
 
 ---
 
+#### 7b. Non-Callable `scope` / `default_scope` Bodies Stop Working
+
+**What Changed:**
+Rails 4.0 deprecated a scope body that is not callable but kept accepting it. Rails 4.1 removes both deprecation paths:
+
+- `scope :active, where(active: true)` — 4.1 calls `body.call` unconditionally, so a stored `Relation` raises `NoMethodError: undefined method 'call'`. It raises **lazily, the first time the scope is called**, not at boot, so a clean boot proves nothing. (Rails 4.2 adds a class-load guard that raises `ArgumentError, 'The scope body needs to be callable.'` instead.)
+- `default_scope where(deleted_at: nil)` — 4.1 raises `ArgumentError: Support for calling #default_scope without a block is removed` at class-definition time, which fails boot or eager load.
+
+**Detection Pattern:**
+```ruby
+scope :active, where(active: true)        # any non-callable body, not just where()
+scope :ordered, order(:position)
+default_scope where(deleted_at: nil)
+```
+
+**Fix:**
+```ruby
+scope :active, -> { where(active: true) }
+scope :ordered, -> { order(:position) }
+default_scope { where(deleted_at: nil) }
+```
+
+If you are coming from 4.0 this should already be done — but re-run the check, because on 4.0 the old form only *warned* while silently returning wrong rows, so a codebase that "worked fine" on 4.0 can still be carrying these. See section 3a of the 3.2 → 4.0 guide for the Rails-source explanation and the SQL evidence.
+
+Grep for the wrapped form too. A body that starts on the line *after* the declaration is invisible to a line-oriented search for `scope :name, <body>`:
+
+```ruby
+scope :with_author,
+  joins(:author)      # still non-callable, still raises on 4.1
+```
+
+Search `^\s*scope\s+:\w+\s*,\s*$` as well, and read the continuation line.
+
+---
+
+#### 7c. `scope` Rejects a Name Active Record Already Defines
+
+**What Changed:**
+Rails 4.1 added a name check to `ActiveRecord::Scoping::Named#scope`:
+
+```ruby
+if dangerous_class_method?(name)
+  raise ArgumentError, "You tried to define a scope named \"#{name}\" " \
+    "on the model \"#{self.name}\", but Active Record already defined " \
+    "a class method with the same name."
+end
+```
+
+It fires at **class-definition time**, so one colliding scope anywhere stops boot or eager load. Rails 4.0's `scope` has no name check at all, and 3.2 only logged `Creating scope :x. Overwriting existing method`, so a collision can sit in a codebase for years and surface for the first time here.
+
+`none` is the usual casualty. Active Record only gained `Model.none` in 4.0, so an app that hand-rolled one on 3.2 is carrying a name that is now taken:
+
+```ruby
+# common 3.2-era workaround, often tucked inside a concern
+scope :none, -> { where("1=0") }
+```
+
+Note this is orthogonal to section 7b: the scope above *is* callable and still refuses to load.
+
+**Detection Pattern:**
+```ruby
+scope :none, ...
+scope :all, ...
+scope :count, ...     # any name Active Record defines as a class method
+```
+
+**Fix:**
+Delete the scope where the built-in already does the job — `Model.none` returns a `NullRelation` and never queries the database, which is strictly better than `where("1=0")`. Rename it otherwise. Rails' error message is authoritative; a grep list is only a pre-flight, since the check covers every class method Active Record defines.
+
+---
+
 #### 8. `ActiveRecord::Relation` Mutator Methods Removed
 
 **What Changed:**
@@ -619,6 +690,8 @@ Cross-check against [RailsDiff 4.0.13 → 4.1.16](http://railsdiff.org/4.0.13/4.
 7. Swap `post :x, format: :js` for `xhr :post, :x, format: :js` in controller tests.
 8. Update `flash.to_hash` callers to use string keys.
 9. Review `default_scope`-bearing models; apply `unscope`/`rewhere`.
+9b. Wrap every remaining non-callable `scope` / `default_scope` body in a lambda or block — these raise on 4.1 (section 7b), and on 4.0 they only warned. Include bodies that wrap onto a continuation line.
+9c. Rename or delete any scope whose name Active Record already defines as a class method — `scope :none` above all (section 7c). These fail at class load even when the body is callable.
 10. Convert `Relation.compact!` / `Relation.map!` etc. to `to_a` then mutate.
 11. Replace `render :text` with `:plain` / `:html` / `:body`.
 12. Pin JSON time precision if clients need it (`time_precision = 0`).

--- a/rails-upgrade/version-guides/upgrade-4.1-to-4.2.md
+++ b/rails-upgrade/version-guides/upgrade-4.1-to-4.2.md
@@ -159,6 +159,59 @@ assert_select "a[href='/foo']"
 
 ---
 
+#### 5b. Non-Callable `scope` Body Now Fails at Class Load
+
+**What Changed:**
+Rails 4.2 adds a guard clause to `ActiveRecord::Scoping::Named#scope`:
+
+```ruby
+unless body.respond_to?(:call)
+  raise ArgumentError, 'The scope body needs to be callable.'
+end
+```
+
+This fires while the model class is being defined, so **one non-callable scope anywhere in the app breaks boot or eager load** — a louder failure than 4.1, where the same code raised `NoMethodError` lazily on first call. Non-block `default_scope` already raised at class load in 4.1 and continues to.
+
+**Detection Pattern:**
+```ruby
+scope :active, where(active: true)        # any non-callable body, not just where()
+scope :ordered, order(:position)
+default_scope where(deleted_at: nil)
+```
+
+**Fix:**
+```ruby
+scope :active, -> { where(active: true) }
+scope :ordered, -> { order(:position) }
+default_scope { where(deleted_at: nil) }
+```
+
+Coming from 4.1 this should already be done — the app could not have run otherwise. Re-check anyway if the upgrade skipped a hop (4.0 straight to 4.2), because on 4.0 this form only *warned* while silently returning wrong rows. See section 3a of the 3.2 → 4.0 guide for the Rails-source explanation and the SQL evidence.
+
+A line-oriented grep for `scope :name, <body>` misses a body that wraps onto the next line. Search `^\s*scope\s+:\w+\s*,\s*$` as well and read the continuation line.
+
+---
+
+#### 5c. `scope` Still Rejects a Name Active Record Already Defines
+
+**What Changed:**
+Nothing new in 4.2 — the name check `#scope` gained in 4.1 is still there:
+
+```ruby
+if dangerous_class_method?(name)
+  raise ArgumentError, "You tried to define a scope named \"#{name}\" " \
+    "on the model \"#{self.name}\", but Active Record already defined " \
+    "a class method with the same name."
+end
+```
+
+It matters here only for an app that skipped 4.1 and went 4.0 → 4.2 directly: 4.0's `scope` has no name check at all, so the collision surfaces at this hop instead. It fires at class-definition time and stops boot or eager load. `scope :none` is the usual casualty — Active Record gained `Model.none` in 4.0, so a hand-rolled 3.2-era version is carrying a name that is now taken. This is orthogonal to 5b: a colliding scope can be perfectly callable and still refuse to load.
+
+**Fix:**
+Delete the scope where the built-in already does the job (`Model.none` returns a `NullRelation` without querying), rename it otherwise. See section 7c of the 4.0 → 4.1 guide for the full treatment.
+
+---
+
 ### 🟡 MEDIUM PRIORITY
 
 #### 6. HTML Sanitizer Rewritten (Loofah/Nokogiri)
@@ -489,6 +542,7 @@ Cross-check against [RailsDiff 4.1.16 → 4.2.11.3](http://railsdiff.org/4.1.16/
 1. Replace `.deliver` / `.deliver!` with `.deliver_now` / `.deliver_now!` (or `.deliver_later` for async)
 2. Replace `.find(obj)` / `.exists?(obj)` with `.find(obj.id)` / `.exists?(obj.id)`
 3. Replace `assert_tag` with `assert_select`
+3b. Wrap any remaining non-callable `scope` / `default_scope` body in a lambda or block — these now raise at class load (section 5b)
 4. Update `Procfile` with `-b 0.0.0.0` if external access needed
 5. Review HTML sanitizer output in tests
 6. Add `config.active_record.raise_in_transactional_callbacks = true`
@@ -524,6 +578,14 @@ Cross-check against [RailsDiff 4.1.16 → 4.2.11.3](http://railsdiff.org/4.1.16/
 **Cause:** Extracted to the `responders` gem
 
 **Fix:** `gem 'responders', '~> 2.0'`
+
+### Issue: Boot fails with "The scope body needs to be callable."
+
+**Error:** `ArgumentError: The scope body needs to be callable.`
+
+**Cause:** A model declares `scope :name, where(...)` without wrapping the body in a lambda. Rails 4.2 raises while the class loads. The backtrace names the model, not the scope, so grep the file for `scope :` declarations whose body is a bare relation.
+
+**Fix:** `scope :name, -> { where(...) }` — see section 5b
 
 ### Issue: Transactional callback bugs became silent
 


### PR DESCRIPTION
## Why

A non-callable scope body is not a style issue on Rails 4.0. It silently returns wrong rows, and the skill treated it as a mechanical rewrite.

Rails 3.2 merged the stored relation into the current scope at call time, so an association's condition survived. Rails 4.0 returns it verbatim on the non-callable branch — no `merge`, no `scoping` — so everything to the left is discarded:

```sql
-- 3.2, and 4.0 with `scope :active, -> { where(deleted: nil) }`
WHERE `issues`.`incident_id` = 123 AND `issues`.`deleted` IS NULL

-- 4.0 with `scope :active, where(deleted: nil)`
WHERE `issues`.`deleted` IS NULL
```

Rails only warns, at class-definition time. This shipped to production in a real 3.2 → 4.0 upgrade: a page called `incident.issues.active` to decide whether a record was editable, the unbounded read killed the worker, and it surfaced as a 503. Dev and CI held too little data for the query to be slow, so every pre-production gate passed.

The old detection regex looked only for `where`, so it also missed `order(...)`, `joins(...)` and `scoped.where(...)`.

## What changed

**Widened detection.** `SCOPE_WITHOUT_LAMBDA` now matches any non-callable body, and `DEFAULT_SCOPE_WITHOUT_BLOCK` any non-block argument (it was `where|order|:order`, missing `default_scope joins(...)` and friends). Both excludes are anchored to the body position and tolerate a wrapping paren.

**New patterns.** `SCOPE_BODY_CONTINUATION` for a body that wraps onto the next line, which a line-oriented pattern cannot classify — flagged for human review rather than dropped. `SCOPE_NAME_COLLISION` for the name guard 4.1 added to `#scope`; `scope :none` is the usual casualty, since Active Record gained `Model.none` in 4.0 and a hand-rolled 3.2-era scope now collides.

**Per-hop coverage.** The same defect has a different symptom at each version, so each hop's pattern file and guide carries its own entry:

| Hop | Symptom | Guide |
|---|---|---|
| 3.2 → 4.0 | warns, silently wrong rows | 3a, rewritten |
| 4.0 → 4.1 | `NoMethodError`, lazily on first call; colliding names rejected | 7b, 7c |
| 4.1 → 4.2 | `ArgumentError` at class load | 5b, 5c |

**Guides.** Section 3a now carries the 3.2-vs-4.0 `#scope` source, the measured `to_sql`, a per-version behavior table, and an auditing order that starts with association call sites — the only places where the bug is observable. Plus troubleshooting rows for the symptoms as an operator actually meets them: a query returning the whole table, an unexplained 503, `ArgumentError: The scope body needs to be callable.`

**`CLAUDE.md`.** New `kind:` rule: *a deprecation that changes query results is `breaking` at the hop where the behavior changes*. The deciding question is whether a green suite and a clean boot can hide it, not whether Rails prints a warning. Without this, the rubric's rule 2 argues for downgrading the 4.0 entry to `deprecation`. Also corrected the section's example, which claimed this API was deprecated in 3.1 and raised in 4.0 — verified against the gems: 3.1 had no deprecation, and 4.0 warns.

## Verification

Behavior confirmed against the vendored activerecord 3.2.22.5 and 4.0.13 gems and the tagged v4.1.0 / v4.2.0 sources. The SQL was measured by running both boots of a real dual-boot app, not inferred.

Both regexes were run against a ~900-scope Packwerk codebase before and after its own sweep:

- scope bodies: 17 findings with the old regex, 23 with the new one, 0 false positives on the swept branch
- `default_scope`: 0 of 7 declarations flagged (all block form), after a `\b` guard was added — the first run matched a `default_scoper` helper call

Both false positives that run surfaced (a parenthesised `proc` body, `default_scoper`) are now fixtures. `bin/validate-patterns`, `bin/test-patterns` (both with `--self-test`) and `bin/lint-skill` pass.

## Note for reviewers

`SCOPE_WITHOUT_LAMBDA` stays `kind: breaking` at the 4.0 hop even though Rails 4.0 only warns. That is deliberate and the pattern entries carry inline comments saying so — the failure mode is wrong query results, which a passing test suite hides. `DEFAULT_SCOPE_WITHOUT_BLOCK` is also kept `breaking` at 4.0, where it is genuinely deprecated-but-correct, so that it gets fixed in the same pass as the scope bodies rather than sending someone back over the same models at 4.1.
