### PR TITLE
Add remote-form CSRF token coverage for the 3.2 to 4.0 hop

### DIFF
--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.expectations.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.expectations.yml
@@ -458,3 +458,22 @@ RACK_LOCK_MIDDLEWARE:
     - '    config.middleware.use Rack::Lock'
     # commented-out line is inert
     - '    # config.middleware.insert_before Rack::Lock'
+
+REMOTE_FORM_CSRF_TOKEN:
+  # Pattern: form helpers carrying remote: true (either hash syntax).
+  # Remote links and plain forms are not affected.
+  match:
+    - '= form_for @user, remote: true do |f|'
+    - '  <%= form_tag(search_path, remote: true) do %>'
+    - '= form_for @person, :remote => true, html: { class: "opt-in-form" } do |f|'
+    - '= simple_form_for @user, remote: true do |f|'
+    - '= form_for [clinic, patient], url: settings_path, remote: true do |f|'
+  no_match:
+    # remote link_to: UJS builds the form and its token itself
+    - '= link_to "Delete", user_path(user), remote: true, method: :delete'
+    # button_to renders its own token_tag on POST, regardless of this config
+    - '= button_to "Save", settings_path, remote: true'
+    # not a remote form
+    - '= form_for @user do |f|'
+    # the config pin itself, not a form
+    - '    config.action_view.embed_authenticity_token_in_remote_forms = true'

--- a/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
+++ b/rails-upgrade/detection-scripts/patterns/rails-40-patterns.yml
@@ -317,6 +317,18 @@ upgrade_findings:
       fix: "Extract the inline module out of the route file into a conventional autoload path so the constant is loaded the same way on both Rails versions. This fix is version-agnostic — no `NextRails.next?` branch is needed, because an autoloaded constant survives the routes-reload boundary on 4.0 and loads identically on 3.2. Steps: (1) Move the definition into an autoload location that mirrors the constant name, e.g. `Constraints::Admin` → `app/constraints/constraints/admin.rb`. Every directory under `app/` is on the autoload path by default on both 3.2 and 4.0, so no config change is needed; only if you place the file under `lib/` do you add `config.autoload_paths += [Rails.root.join(\"lib\")]` in `config/application.rb`. (2) Delete the `module ... end` wrapper from the route file, leaving only the usage. BEFORE (config/routes/admin.rb): `module Constraints; class Admin; def matches?(req); ...; end; end; end` followed by the `Rails.application.routes.draw` block that calls `constraints Constraints::Admin.new do ... end`. AFTER: the `module`/`class` block lives in `app/constraints/constraints/admin.rb`; the route file keeps only the `constraints Constraints::Admin.new do ... end` usage and no longer defines the constant"
       variable_name: "ROUTES_TOP_LEVEL_MODULE_AUTOLOAD"
 
+    - name: "Remote form that relies on an embedded CSRF token"
+      kind: "breaking"
+      pattern: "(form_for|form_tag|form_with|simple_form_for)[^\\n]*(remote:\\s*true|:remote\\s*=>\\s*true)"
+      exclude: ""
+      search_paths:
+        - "app/views/"
+        - "app/helpers/"
+        - "app/cells/"
+      explanation: "Rails 4.0 flips the default of config.action_view.embed_authenticity_token_in_remote_forms from true to false, so remote forms stop rendering the hidden authenticity_token field. From then on the token reaches the server only as the X-CSRF-Token header that rails-ujs sets from the csrf-token meta tag. Any submit path that does not go through rails-ujs (custom fetch / XHR that posts a FormData built from the form, a jQuery-triggered submit, an iframe upload, a form serialized by a plugin) posts with no CSRF token at all, and bare protect_from_forgery nulls the session instead of raising, so the request silently loses its user rather than erroring. Nothing in the test suite catches it: allow_forgery_protection is false in the test environment, and rack_test drivers never run the JavaScript that does the submitting. The regex flags remote form helpers; remote link_to links are safe (rails-ujs builds their form and token itself), and so is button_to, which renders its own token_tag on POST and never consults this config, so neither is in the regex. The regex also matches one line at a time, so a form helper split across lines with remote: true on a continuation line is missed, so this is a list of forms to audit, not a list of forms to change"
+      fix: "Set config.action_view.embed_authenticity_token_in_remote_forms = true in config/application.rb to keep the Rails 3.2 behavior on both sides of a dual boot, then audit the JavaScript that submits each flagged form: anything not driven by rails-ujs needs the X-CSRF-Token header set explicitly. See section 6 of version-guides/upgrade-3.2-to-4.0.md"
+      variable_name: "REMOTE_FORM_CSRF_TOKEN"
+
   medium_priority:
     - name: "rescue_action method"
       kind: "breaking"

--- a/rails-upgrade/version-guides/upgrade-3.2-to-4.0.md
+++ b/rails-upgrade/version-guides/upgrade-3.2-to-4.0.md
@@ -367,9 +367,103 @@ get '/home' => 'home#index'
 
 ---
 
+#### 6. Remote Forms Stop Embedding the CSRF Token
+
+**What Changed:**
+`config.action_view.embed_authenticity_token_in_remote_forms` defaults to `false` in
+Rails 4.0 (it was `true` in 3.2), so `remote: true` forms no longer render the hidden
+`authenticity_token` field. From then on the token reaches the server only as the
+`X-CSRF-Token` header that rails-ujs sets from the `csrf-token` meta tag, which means
+the form is protected only while UJS is the thing submitting it. Any other submit path
+(a hand-rolled `fetch` posting a `FormData` built from the form, an iframe upload, a
+form serialized by a plugin) posts with no CSRF token at all. With a bare
+`protect_from_forgery`, Rails 4.0 does not raise: the `:null_session` strategy empties
+the session, so the request arrives without its user and fails somewhere further in, or
+silently does nothing.
+
+Rails made the change for fragment caching. The token is per-session, so the hidden
+field makes the form's HTML unique per user: cache that fragment and you either serve
+one user's token to everybody or you cannot cache it at all. Remote forms were assumed
+to always be submitted by UJS as an XHR, which in a real application they are not. The
+[Rails CHANGELOG entry for the flip](https://github.com/rails/rails/commit/128cfbdf4d316a544a76e5c58dbeac153f3d4e36)
+names the escape hatch: set the config to `true`, or pass `:authenticity_token => true`
+per form. Later Rails
+[softened the default to `nil`](https://github.com/rails/rails/commit/6309b85100dd2b55c716ee4a4e9cbd3da2dc0617),
+meaning "let the form helper decide", so pinning it back is not fighting the
+framework's direction.
+
+Nothing warns, and no test catches it. The Rails-side change is the *absence* of a
+config line, so no grep can see it; the failure is browser-only, so `rack_test` never
+runs the JavaScript that does the submitting; and `allow_forgery_protection` is off in
+the test environment, so no token is rendered in tests either way.
+
+**Detection Pattern:**
+```bash
+# remote forms whose submit path needs auditing, both hash syntaxes
+grep -rnE "remote:\s*true|:remote\s*=>\s*true" app/views/ app/helpers/
+
+# confirm the app never pinned the config
+grep -rn "embed_authenticity_token_in_remote_forms" config/
+
+# true on the current boot and false on the next confirms it relies on the default
+bundle exec rails runner 'puts ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms.inspect'
+BUNDLE_GEMFILE=Gemfile.next bundle exec rails runner 'puts ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms.inspect'
+```
+
+Remote `link_to` / `button_to` links are safe: UJS builds their form and token itself.
+The grep is a list of forms to audit, not a list of forms to change.
+
+**Fix:**
+```ruby
+# config/application.rb
+# Pinned to the Rails 3.2 default: Rails 4.0 stops embedding the token in
+# remote forms, leaving custom JS submit paths with no CSRF token at all.
+config.action_view.embed_authenticity_token_in_remote_forms = true
+```
+
+Valid on both 3.2 and 4.x, so no `NextRails.next?` branch. The pin is a backstop, not
+the whole fix. Any `fetch` / `XMLHttpRequest` that posts form data itself still needs
+the token set explicitly:
+
+```javascript
+fetch(url, {
+  method: "POST",
+  body: new FormData(form),
+  headers: { "X-CSRF-Token": document.querySelector("meta[name=csrf-token]").content }
+})
+```
+
+Check that the layout renders `csrf_meta_tags`. Without it there is no token to read,
+and UJS has nothing to send either.
+
+**Catch it in the suite:** one example with forgery protection switched on. It goes red
+on the next boot and green after the pin, and flipping the flag is the whole trick,
+since the test environment disables it:
+
+```ruby
+around do |example|
+  was_protecting = ActionController::Base.allow_forgery_protection
+  ActionController::Base.allow_forgery_protection = true
+  example.run
+  ActionController::Base.allow_forgery_protection = was_protecting
+end
+
+it "embeds an authenticity token in the remote form" do
+  visit edit_settings_path
+
+  expect(page).to have_css("form.opt-in-form input[name='authenticity_token']", visible: :all)
+end
+```
+
+Related: **4.2** masks the token per request (`CSRF_TOKEN_MASKING`), so any client that
+caches a token across requests breaks there. **7.0** replaces UJS with Turbo and the
+submit path changes again.
+
+---
+
 ### 🟡 MEDIUM PRIORITY
 
-#### 6. `rescue_action` Removed — Use `rescue_from`
+#### 7. `rescue_action` Removed — Use `rescue_from`
 
 **What Changed:**
 The `rescue_action` method was removed in Rails 4.0 with no deprecation warning. Use `rescue_from` instead.
@@ -401,7 +495,7 @@ Note: `rescue_from` does not support `super`, so re-raise the exception if neede
 
 ---
 
-#### 7. Partial Magic Variables Removed
+#### 8. Partial Magic Variables Removed
 
 **What Changed:**
 In Rails 3.2, rendering a partial automatically defined a local variable named after the partial (set to `nil` if no object/collection was passed). Rails 4.0 only defines this variable when rendering with `collection:` or `object:` options. Partials that rely on the implicit variable will raise `undefined local variable or method` errors.
@@ -458,7 +552,7 @@ Results need manual review — only partials rendered without `collection:`, `ob
 
 ---
 
-#### 8. `cache_key` Timestamp Format Changed
+#### 9. `cache_key` Timestamp Format Changed
 
 **What Changed:**
 The `cache_timestamp_format` changed from `:number` to `:nsec`, producing longer, more precise cache keys. This can break code that compares or stores cache keys as strings.
@@ -487,7 +581,7 @@ If your code stores cache keys externally (e.g., in Redis, a database, or a back
 
 ---
 
-#### 9. Observers Extracted
+#### 10. Observers Extracted
 
 **What Changed:**
 ActiveRecord Observers are no longer included by default.
@@ -500,7 +594,7 @@ gem 'rails-observers'
 
 ---
 
-#### 10. ActionController Sweeper Extracted
+#### 11. ActionController Sweeper Extracted
 
 **What Changed:**
 Sweepers are no longer included.
@@ -511,11 +605,11 @@ Sweepers are no longer included.
 gem 'rails-observers'
 ```
 
-Note: This is the same gem as #9 (Observers) — `rails-observers` bundles both Observers and Sweepers.
+Note: This is the same gem as #10 (Observers) — `rails-observers` bundles both Observers and Sweepers.
 
 ---
 
-#### 11. Action Caching Extracted
+#### 12. Action Caching Extracted
 
 **What Changed:**
 `caches_page` and `caches_action` are no longer included.
@@ -534,7 +628,7 @@ gem 'actionpack-action_caching'
 
 ---
 
-#### 12. ActiveResource Extracted
+#### 13. ActiveResource Extracted
 
 **What Changed:**
 ActiveResource is no longer included.
@@ -547,7 +641,7 @@ gem 'activeresource'
 
 ---
 
-#### 13. Plugins No Longer Supported
+#### 14. Plugins No Longer Supported
 
 **What Changed:**
 Rails 4.0 dropped support for `vendor/plugins`.
@@ -561,7 +655,7 @@ Rails 4.0 dropped support for `vendor/plugins`.
 
 ### 🟢 LOW PRIORITY (but commonly encountered)
 
-#### 14. Fixture Dates Must Be Cast to Strings
+#### 15. Fixture Dates Must Be Cast to Strings
 
 **What Changed:**
 Rails 4 is stricter about date parsing in YAML fixtures. Dynamic date expressions like `<%= 3.days.ago %>` can produce `invalid date` errors in tests.
@@ -584,7 +678,7 @@ accepted_at: "<%= 3.days.ago.to_s(:db) %>"
 
 ---
 
-#### 15. `config.eager_load` Required in All Environments
+#### 16. `config.eager_load` Required in All Environments
 
 **What Changed:**
 Rails 4.0 requires `config.eager_load` to be set in every environment file. Without it, Rails raises an error on boot.
@@ -600,7 +694,7 @@ config.eager_load = false
 
 ---
 
-#### 16. `config.assets.compress` Removed
+#### 17. `config.assets.compress` Removed
 
 **What Changed:**
 The `config.assets.compress` directive no longer works in Rails 4. It has been replaced by specific compressor settings.
@@ -622,7 +716,7 @@ config.assets.css_compressor = :sass
 
 ---
 
-#### 17. `ActiveSupport::BufferedLogger` Renamed
+#### 18. `ActiveSupport::BufferedLogger` Renamed
 
 **What Changed:**
 `ActiveSupport::BufferedLogger` was renamed to `ActiveSupport::Logger`.
@@ -646,7 +740,7 @@ Logger.const_get(Rails.configuration.log_level.to_s.upcase)
 
 ---
 
-#### 18. `config.paths["config/routes"]` Key Changed
+#### 19. `config.paths["config/routes"]` Key Changed
 
 **What Changed:**
 The config path key for routes changed from `"config/routes"` to `"config/routes.rb"`.
@@ -667,7 +761,7 @@ config.paths["config/routes.rb"].concat(...)
 
 ---
 
-#### 19. `select('distinct ...').pluck` → `.distinct.pluck`
+#### 20. `select('distinct ...').pluck` → `.distinct.pluck`
 
 **What Changed:**
 Rails 4 introduced the `.distinct` query method as the preferred way to get distinct results.
@@ -688,7 +782,7 @@ relation.distinct.pluck(:assigned_to_id)
 
 ---
 
-#### 20. `assign_attributes` Method Signature Changed
+#### 21. `assign_attributes` Method Signature Changed
 
 **What Changed:**
 In Rails 3.2, `assign_attributes` accepted an options hash as a second argument. In Rails 4.0, the options argument was removed and the method was aliased to `attributes=`.
@@ -711,7 +805,7 @@ assign_attributes(new_attributes)
 
 ---
 
-#### 21. Validation Callback API Changed
+#### 22. Validation Callback API Changed
 
 **What Changed:**
 The internal method `_run_validation_callbacks` was replaced with `run_callbacks(:validation)`.
@@ -732,7 +826,7 @@ run_callbacks(:validation)
 
 ---
 
-#### 22. Test Request Headers API Changed
+#### 23. Test Request Headers API Changed
 
 **What Changed:**
 In controller specs, setting request headers changed from `request.env` to `request.headers`.
@@ -753,7 +847,7 @@ request.headers.merge!(headers)
 
 ---
 
-#### 23. `ActiveRecord::ImmutableRelation` Error
+#### 24. `ActiveRecord::ImmutableRelation` Error
 
 **What Changed:**
 In Rails 4, calling methods like `count` on a relation that has already been loaded or modified can raise `ActiveRecord::ImmutableRelation`.
@@ -768,7 +862,7 @@ Rewrite the query to avoid modifying a frozen relation, e.g., use `.distinct.cou
 
 ---
 
-#### 24. PaperTrail Version Models Require `VersionConcern`
+#### 25. PaperTrail Version Models Require `VersionConcern`
 
 **What Changed:**
 If using PaperTrail with custom version models (subclassing `Version`), Rails 4 requires explicitly including `PaperTrail::VersionConcern`.
@@ -892,14 +986,15 @@ Error → section lookup for the most common errors encountered during this upgr
 | Scope returns wrong results or errors | Section 3a (Scopes) — add lambda |
 | `Unknown key: :conditions` | Section 3b (Association conditions) — move to lambda |
 | `No route matches` | Section 5 (Routes) — add HTTP method |
-| `NoMethodError: undefined method 'rescue_action'` | Section 6 (rescue_action) — use `rescue_from` |
-| `undefined local variable or method` in partial | Section 7 (Partial magic variables) — pass `locals:` |
-| Cache misses after upgrade | Section 8 (cache_key format) — changed to `:nsec` |
-| `invalid date` in fixtures | Section 14 (Fixture dates) — cast with `.to_s(:db)` |
-| `eager_load is set to nil` | Section 15 (config.eager_load) — set in all environments |
-| `NameError: uninitialized constant ActiveSupport::BufferedLogger` | Section 17 (BufferedLogger) — renamed to `ActiveSupport::Logger` |
-| `ActiveRecord::ImmutableRelation` | Section 23 (ImmutableRelation) — use `.distinct.count` |
-| Controller specs don't see custom headers | Section 22 (Test headers) — use `request.headers.merge!` |
+| Remote form POST arrives with no session or current user | Section 6 (Remote form CSRF) — pin `embed_authenticity_token_in_remote_forms` |
+| `NoMethodError: undefined method 'rescue_action'` | Section 7 (rescue_action) — use `rescue_from` |
+| `undefined local variable or method` in partial | Section 8 (Partial magic variables) — pass `locals:` |
+| Cache misses after upgrade | Section 9 (cache_key format) — changed to `:nsec` |
+| `invalid date` in fixtures | Section 15 (Fixture dates) — cast with `.to_s(:db)` |
+| `eager_load is set to nil` | Section 16 (config.eager_load) — set in all environments |
+| `NameError: uninitialized constant ActiveSupport::BufferedLogger` | Section 18 (BufferedLogger) — renamed to `ActiveSupport::Logger` |
+| `ActiveRecord::ImmutableRelation` | Section 24 (ImmutableRelation) — use `.distinct.count` |
+| Controller specs don't see custom headers | Section 23 (Test headers) — use `request.headers.merge!` |
 
 ---
 


### PR DESCRIPTION
Rails 4.0 flips `embed_authenticity_token_in_remote_forms` to `false`, so `remote: true` forms stop rendering the hidden `authenticity_token`. The token then only reaches the server as the `X-CSRF-Token` header UJS sets, so any submit path that bypasses UJS posts with no token. A bare `protect_from_forgery` nulls the session instead of raising, so the request silently loses its user.

Nothing warns and no test catches it: the Rails-side change is an absent config line, the failure is browser-only, and `allow_forgery_protection` is off in the test environment.

